### PR TITLE
Resolve #6: automate authserver deployment

### DIFF
--- a/auth/.gitignore
+++ b/auth/.gitignore
@@ -1,2 +1,3 @@
 hyauth
 goroot
+*.deb

--- a/auth/auth.postinstall
+++ b/auth/auth.postinstall
@@ -1,0 +1,5 @@
+cp -i /etc/ssh/sshd_config.hyades-new /etc/ssh/sshd_config
+adduser --system --shell /usr/bin/hyauth kauth
+touch /home/kauth/.k5login
+touch /root/.k5login
+sed -i -E "s/^(session .+ pam_motd.so .+)$/#\1/g" /etc/pam.d/sshd

--- a/auth/auth.postremove
+++ b/auth/auth.postremove
@@ -1,0 +1,7 @@
+sed -i -E "s/^#(session .+ pam_motd.so .+)$/\1/g" /etc/pam.d/sshd
+mv /etc/ssh/sshd_config /etc/ssh/sshd_config.rmtmp
+dpkg-divert --remove --package hyades-authserver --rename /etc/ssh/sshd_config
+if [ ! -e /etc/ssh/sshd_config ]
+then
+	mv /etc/ssh/sshd_config.rmtmp /etc/ssh/sshd_config
+fi

--- a/auth/auth.preinstall
+++ b/auth/auth.preinstall
@@ -1,0 +1,1 @@
+dpkg-divert --add --package hyades-authserver --rename --divert /etc/ssh/sshd_config.before-hyades /etc/ssh/sshd_config

--- a/auth/build.sh
+++ b/auth/build.sh
@@ -7,5 +7,7 @@ rm -rf goroot
 mkdir goroot
 (cd goroot && tar -xf ../golang-x-crypto-5ef0053f77724838734b6945dd364d3847e5de1d.tar.xz src)
 GOPATH=$(pwd)/goroot go build hyauth.go
-cp hyauth ../binaries/hyauth
+
+./package.sh
+
 echo "Build complete!"

--- a/auth/deploy.sh
+++ b/auth/deploy.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [ "$1" = "" -o "$2" = "" -o "$3" = "" -o "$4" = "" ]
+then
+	echo "Usage: $0 <host> <keytab> <acl> <ca> [package]" 1>&2
+	echo "  NOTE: The keytab is not automatically rotated!" 1>&2
+	exit 1
+fi
+
+set -e -u
+
+HOST=$1
+KEYTAB=$2
+ACL=$3
+CA=$4
+PACKAGE=${5:-$(dirname $0)/hyades-authserver_0.1.4-1_amd64.deb}
+
+if [ ! -e $KEYTAB ]
+then
+	echo "Could not find keytab." 1>&2
+	exit 1
+fi
+
+if [ ! -e $ACL ]
+then
+	echo "Could not find acl." 1>&2
+	exit 1
+fi
+
+if [ ! -e $CA -o ! -e $CA.pub ]
+then
+	echo "Could not find ca and ca.pub." 1>&2
+	exit 1
+fi
+
+if [ ! -e $PACKAGE ]
+then
+	echo "Could not find package." 1>&2
+	exit 1
+fi
+
+if ssh root@${HOST} test ! -e /etc/krb5.keytab
+then
+	echo "Uploading keytab..."
+	scp $KEYTAB root@${HOST}:/etc/krb5.keytab
+else
+	echo "Keytab already exists -- skipping."
+fi
+
+scp ${PACKAGE} root@${HOST}:/root/hyauth-pkg-install.deb
+scp ${ACL} root@${HOST}:/root/.k5login
+ssh root@${HOST} 'apt-get install krb5-user && dpkg -i /root/hyauth-pkg-install.deb && rm /root/hyauth-pkg-install.deb'
+scp ${ACL} root@${HOST}:/home/kauth/.k5login
+scp ${CA} root@${HOST}:/home/kauth/ca_key
+scp ${CA}.pub root@${HOST}:/home/kauth/ca_key.pub
+ssh root@${HOST} chown kauth /home/kauth/ca_key
+ssh root@${HOST} systemctl restart ssh
+
+echo "Finished!"

--- a/auth/package.sh
+++ b/auth/package.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e -u
+
+VERSION=0.1.4
+
+cd $(dirname $0)
+HERE=$(pwd)
+HYBIN=$(pwd)/../binaries/
+mkdir -p ${HYBIN}
+
+FPMOPT="-s dir -t deb"
+FPMOPT="$FPMOPT -n hyades-authserver -v ${VERSION} --iteration 1"
+FPMOPT="$FPMOPT --maintainer 'sipb-hyades-root@mit.edu'"
+FPMOPT="$FPMOPT --license MIT -a x86_64"
+FPMOPT="$FPMOPT --depends krb5-user"
+FPMOPT="$FPMOPT --after-install auth.postinstall --after-remove auth.postremove --before-install auth.preinstall"
+FPMOPT="$FPMOPT hyauth=/usr/bin/hyauth sshd_config=/etc/ssh/sshd_config.hyades-new"
+
+fpm --vendor 'MIT SIPB Hyades Project' $FPMOPT
+
+echo "authserver package built!"

--- a/auth/sshd_config
+++ b/auth/sshd_config
@@ -1,0 +1,67 @@
+# This is the Homeworld authserver sshd configuration file.
+
+Port 22
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
+
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+RekeyLimit default none
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+
+LoginGraceTime 2m
+PermitRootLogin prohibit-password
+StrictModes yes
+MaxAuthTries 6
+MaxSessions 10
+
+PubkeyAuthentication yes
+
+AuthorizedKeysFile none
+AuthorizedPrincipalsFile none
+
+HostbasedAuthentication no
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+
+KerberosAuthentication no
+
+GSSAPIAuthentication yes
+GSSAPICleanupCredentials yes
+GSSAPIStrictAcceptorCheck yes
+GSSAPIKeyExchange no
+
+UsePAM yes
+
+AllowAgentForwarding no
+AllowTcpForwarding no
+GatewayPorts no
+X11Forwarding no
+PermitTTY yes
+PrintMotd no
+PrintLastLog no
+TCPKeepAlive yes
+UseLogin no
+UsePrivilegeSeparation sandbox
+PermitUserEnvironment no
+Compression delayed
+ClientAliveInterval 15
+ClientAliveCountMax 3
+UseDNS no
+MaxStartups 10:30:100
+PermitTunnel no
+ChrootDirectory none
+VersionAddendum none
+
+Banner none
+
+AcceptEnv LANG LC_*

--- a/build-etcd/build.sh
+++ b/build-etcd/build.sh
@@ -3,7 +3,6 @@ set -e -u
 VERSION=3.1.7
 
 cd $(dirname $0)
-HERE=$(pwd)
 HYBIN=$(pwd)/../binaries/
 mkdir -p ${HYBIN}
 

--- a/deploy.md
+++ b/deploy.md
@@ -18,27 +18,12 @@
 
 ## Set up the authentication server
 
-(IF YOU ARE REINITIALIZING AN AUTHSERVER, MAKE SURE TO COPY OFF THE KEYTAB AND SSH CA!)
-
-TODO: automate this process better
-
  * Request a keytab from accounts@, if necessary.
- * Provision yourself a Debian Stretch machine. Choose SSH Server and Standard System Utilities.
-   * Remove irrelevant things like exim4 if necessary.
- * Install krb5-user
- * Stick keytab into /etc/krb5.keytab
- * k5srvutil change
- * Consider backing up new keytab
- * Create user kauth with a homedir
- * Set up the ACL for the authserver in kauth's .k5login.
- * Generate yourself a SSH user CA, if necessary. '/home/kauth/ca_key'.
- * Back up the user CA somewhere, probably?
- * Copy the user CA pubkey off of the server.
- * Setup SSH access via kerberos, or, if you don't have the keytab yet, SSH keys.
- * Turn off PasswordAuthentication.
- * Set up a .k5login in the homedir of any user with shell access, even if empty.
- * Upload hyauth to /usr/local/bin/hyauth
- * Set hyauth as kauth's shell
+ * Provision yourself a Debian Stretch machine. Choose SSH Server.
+ * Establish SSH access somehow (i.e. ssh keys)
+ * Generate ssh user CA locally; save it somewhere safe.
+ * Rotate the keytab locally (k5srvutil -f <keytab> change); save it somewhere safe.
+ * Run auth/deploy.sh on <host> <keytab> auth-login <user-ca>
 
  * Run req-cert and see if it works.
 
@@ -71,6 +56,7 @@ TODO: improve cryptographic strength of keytab (see note on sipb page)
  * Run certificate-upload-certs.sh
  * Run spin-up-all.sh
  * Run pkg-install-all.sh on the latest packages and etcd-current-linux-amd64.aci
+	DO NOT INCLUDE hyades-authserver IN THIS INSTALLATION!
 
 ## Starting everything
 


### PR DESCRIPTION
Creates a package (with partial automation) and a script to help install and deploy.

Also revises the instructions on deployment to match the new process.