### PR TITLE
Minor improvements to TLS handling

### DIFF
--- a/building/build-debs/homeworld-keyserver/src/authorities/ssh_test.go
+++ b/building/build-debs/homeworld-keyserver/src/authorities/ssh_test.go
@@ -109,7 +109,7 @@ func TestSignSSHUserCertificate(t *testing.T) {
 					t.Error("Mismatch on keyid")
 				}
 				if cert.Serial == 0 || len(cert.Nonce) < 16 || bytes.Count(cert.Nonce, []byte{0}) > 4 {
-					t.Error("Lacking populated fields: %d %s", cert.Serial, cert.Nonce)
+					t.Errorf("Lacking populated fields: %d %s", cert.Serial, cert.Nonce)
 				}
 			}
 		}
@@ -159,7 +159,7 @@ func TestSignSSHHostCertificate(t *testing.T) {
 					t.Error("Mismatch on keyid")
 				}
 				if cert.Serial == 0 || len(cert.Nonce) < 16 || bytes.Count(cert.Nonce, []byte{0}) > 4 {
-					t.Error("Lacking populated fields: %d %s", cert.Serial, cert.Nonce)
+					t.Errorf("Lacking populated fields: %d %s", cert.Serial, cert.Nonce)
 				}
 			}
 		}

--- a/building/build-debs/homeworld-keyserver/src/authorities/tls_op_test.go
+++ b/building/build-debs/homeworld-keyserver/src/authorities/tls_op_test.go
@@ -205,7 +205,7 @@ func TestExpiredTLSAuthority(t *testing.T) {
 	defer stop()
 
 	errstr := request("")
-	if string(errstr) != "Certificate for /CN=client-test has expired" {
+	if !strings.Contains(string(errstr), "has expired") {
 		t.Errorf("Mismatch on expected error; did not expect %s", errstr)
 	}
 }
@@ -238,7 +238,7 @@ func TestUnissuedTLSAuthority(t *testing.T) {
 	defer stop()
 
 	errstr := request("")
-	if string(errstr) != "Certificate for /CN=client-test is not yet valid" {
+	if !strings.Contains(string(errstr), "not yet valid") {
 		t.Errorf("Mismatch on expected error; did not expect %s", errstr)
 	}
 }
@@ -262,9 +262,8 @@ func checkClientCertValidity(t *testing.T, clientCertData []byte, key []byte) (s
 	principal := string(request(""))
 	if principal[0] == 'E' {
 		return "", errors.New(principal[1:])
-	} else {
-		return principal[1:], nil
 	}
+	return principal[1:], nil
 }
 
 func TestTLSAuthority_Sign_UserCert(t *testing.T) {
@@ -430,7 +429,7 @@ func TestTLSAuthority_Sign_CheckNames(t *testing.T) {
 
 func TestTLSAuthority_Sign_MalformedPEM(t *testing.T) {
 	a := getTLSAuthority(t)
-	_, err := a.Sign(strings.Replace("I'm literally not a PEM file", "Z", "Y", -1), false, time.Hour, "common-name-tc", []string{"dns1.mit.edu", "18.181.123.456", "dns2.mit.edu", "18.181.123.789"})
+	_, err := a.Sign("I'm literally not a PEM file", false, time.Hour, "common-name-tc", []string{"dns1.mit.edu", "18.181.123.456", "dns2.mit.edu", "18.181.123.789"})
 	if err == nil {
 		t.Error("Expected error while signing malformed CSR")
 	} else if !strings.Contains(err.Error(), "PEM header") {

--- a/building/build-debs/homeworld-keyserver/src/authorities/tls_parse_test.go
+++ b/building/build-debs/homeworld-keyserver/src/authorities/tls_parse_test.go
@@ -41,7 +41,7 @@ func TestTLSEqual(t *testing.T) {
 func TestGetTLSPublicKey(t *testing.T) {
 	pubkey := getTLSAuthority(t).GetPublicKey()
 	if !bytes.Equal(pubkey, []byte(TLS_TEST_CERT)) {
-		t.Error("Mismatch between pubkey and cert: %s versus %s", string(pubkey), TLS_TEST_CERT)
+		t.Errorf("Mismatch between pubkey and cert: %s versus %s", string(pubkey), TLS_TEST_CERT)
 	}
 }
 
@@ -153,7 +153,7 @@ func TestLoadPKCS8Key(t *testing.T) {
 		t.Error("PKCS8 authority is different from PKCS1 authority")
 	}
 	if !privateKeysEqual(authority1.key, authority2.key) {
-		t.Error("PKCS8 key is different from PKCS1 key: %v versus %v", authority1.key, authority2.key)
+		t.Errorf("PKCS8 key is different from PKCS1 key: %v versus %v", authority1.key, authority2.key)
 	}
 }
 

--- a/building/build-debs/homeworld-keyserver/src/operation/operation.go
+++ b/building/build-debs/homeworld-keyserver/src/operation/operation.go
@@ -1,11 +1,12 @@
 package operation
 
 import (
-	"account"
-	"config"
 	"encoding/json"
 	"fmt"
 	"log"
+
+	"account"
+	"config"
 )
 
 type Operation struct {
@@ -41,12 +42,12 @@ func InvokeAPIOperation(ctx *account.OperationContext, gctx *config.Context, API
 	if !found {
 		return "", fmt.Errorf("Account %s does not have access to API call %s", princ, API)
 	}
-	log.Println("Attempting to perform API operation %s for %s", API, princ)
+	log.Printf("Attempting to perform API operation %s for %s", API, princ)
 	response, err := priv(ctx, requestBody)
 	if err != nil {
-		log.Println("Operation %s for %s failed with error: %s.", API, princ, err)
+		log.Printf("Operation %s for %s failed with error: %s.", API, princ, err)
 		return "", err
 	}
-	log.Println("Operation %s for %s succeeded.", API, princ)
+	log.Printf("Operation %s for %s succeeded.", API, princ)
 	return response, nil
 }

--- a/building/build-debs/homeworld-keyserver/src/token/registry_test.go
+++ b/building/build-debs/homeworld-keyserver/src/token/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+
 	"token/scoped"
 )
 
@@ -30,7 +31,7 @@ func TestTokenExpiration(t *testing.T) {
 		}
 	}
 	if len(registry.by_token) != 1 {
-		t.Error("Expiration process did not work properly (%d)", len(registry.by_token))
+		t.Errorf("Expiration process did not work properly (%d)", len(registry.by_token))
 	}
 }
 
@@ -40,7 +41,7 @@ func TestTokenNoExpiration(t *testing.T) {
 		registry.GrantToken("subject", time.Minute)
 	}
 	if len(registry.by_token) != 1000 {
-		t.Error("Non-expiration process did not work properly (%d)", len(registry.by_token))
+		t.Errorf("Non-expiration process did not work properly (%d)", len(registry.by_token))
 	}
 }
 

--- a/building/build-debs/homeworld-keyserver/src/util/substitute_test.go
+++ b/building/build-debs/homeworld-keyserver/src/util/substitute_test.go
@@ -105,7 +105,7 @@ func TestSubstituteAllVars(t *testing.T) {
 	} else {
 		expected := "white: a history of sapphic rose//howling purple//their blue understanding//frolic red"
 		if strings.Join(result, "//") != expected {
-			t.Error("Result mismatch: expected %v, not %v", strings.Split(expected, "//"), result)
+			t.Errorf("Result mismatch: expected %v, not %v", strings.Split(expected, "//"), result)
 		}
 	}
 }


### PR DESCRIPTION
* Use the `Certificate.Verify` method to check certs instead of manually checking the signature and validity of the certificate
* Require TLS version 1.2
* Minor nits