### PR TITLE
homeworld-admin-tools: Extract iso without sudo, using libarchive-tools

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/control
+++ b/building/build-debs/homeworld-admin-tools/debian/control
@@ -2,13 +2,13 @@ Source: homeworld-admin-tools
 Section: misc
 Priority: extra
 Maintainer: Cel Skeggs <cela@mit.edu>
-Build-Depends: debhelper (>= 9), libarchive-tools, zip, python3, python3-yaml
+Build-Depends: debhelper (>= 9), libarchive-tools | bsdtar, zip, python3, python3-yaml
 Standards-Version: 3.9.6
 Vcs-Git: https://github.com/sipb/homeworld.git
 Vcs-Browser: https://github.com/sipb/homeworld/
 
 Package: homeworld-admin-tools
 Architecture: amd64
-Depends: homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, libarchive-tools, python3, python3-yaml, pwgen, genisoimage
+Depends: homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, libarchive-tools | bsdtar, python3, python3-yaml, pwgen, genisoimage
 Description: Homeworld admin-tools package.
  This package is used for code deployment to Homeworld clusters.

--- a/building/build-debs/homeworld-admin-tools/debian/control
+++ b/building/build-debs/homeworld-admin-tools/debian/control
@@ -2,13 +2,13 @@ Source: homeworld-admin-tools
 Section: misc
 Priority: extra
 Maintainer: Cel Skeggs <cela@mit.edu>
-Build-Depends: debhelper (>= 9), zip, python3, sudo, rsync, python3-yaml
+Build-Depends: debhelper (>= 9), libarchive-tools, zip, python3, python3-yaml
 Standards-Version: 3.9.6
 Vcs-Git: https://github.com/sipb/homeworld.git
 Vcs-Browser: https://github.com/sipb/homeworld/
 
 Package: homeworld-admin-tools
 Architecture: amd64
-Depends: homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, python3, rsync, python3-yaml, pwgen, genisoimage
+Depends: homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, libarchive-tools, python3, python3-yaml, pwgen, genisoimage
 Description: Homeworld admin-tools package.
  This package is used for code deployment to Homeworld clusters.

--- a/building/build-debs/homeworld-admin-tools/src/iso.py
+++ b/building/build-debs/homeworld-admin-tools/src/iso.py
@@ -22,12 +22,7 @@ def regen_cdpack(source_iso, dest_cdpack):
         os.mkdir(loopdir)
         cddir = os.path.join(d, "cd")
         os.mkdir(cddir)
-        subprocess.check_call(["sudo", "mount", "-o", "loop", "--", source_iso, loopdir])
-        try:
-            subprocess.check_call(
-                ["rsync", "--quiet", "--archive", "--hard-links", "--exclude=TRANS.TBL", loopdir + "/", cddir])
-        finally:
-            subprocess.check_call(["sudo", "umount", loopdir])
+        subprocess.check_call(["bsdtar", "-xf", source_iso, "-C", cddir])
         subprocess.check_call(["chmod", "+w", "--recursive", cddir])
         subprocess.check_call(["gunzip", os.path.join(cddir, "initrd.gz")])
         subprocess.check_call(["tar", "-czf", dest_cdpack, "-C", d, os.path.basename(cddir)])


### PR DESCRIPTION
A normal build chroot doesn’t (and shouldn’t) give sudo access to the build process, so the build was failing here.