### PR TITLE
Fix spire setup supervisor-ssh crashing when run twice

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.22) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Mark Theng <mtheng@mit.edu>  Sun, 03 Dec 2017 18:43:38 -0500
+
 homeworld-admin-tools (0.1.21) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/src/setup.py
+++ b/building/build-debs/homeworld-admin-tools/src/setup.py
@@ -141,8 +141,10 @@ def setup_supervisor_ssh(ops: Operations, config: configuration.Config) -> None:
         ssh_config = resource.get_resource("sshd_config")
         ops.ssh_upload_bytes("upload new ssh configuration to @HOST", node, ssh_config, "/etc/ssh/sshd_config")
         ops.ssh("reload ssh configuration on @HOST", node, "systemctl", "restart", "ssh")
-        ops.ssh("shift aside old authorized_keys on @HOST", node,
-                "mv", "/root/.ssh/authorized_keys", "/root/original_authorized_keys")
+        ops.ssh_raw("shift aside old authorized_keys on @HOST", node,
+                "if [ -f /root/.ssh/authorized_keys ]; then " +
+                "mv /root/.ssh/authorized_keys " +
+                "/root/original_authorized_keys; fi")
 
 
 def setup_services(ops: Operations, config: configuration.Config) -> None:


### PR DESCRIPTION
Check that the file exists before mv-ing it. Fixes #131.