### PR TITLE
Streamline installation of homeworld-apt-setup

### DIFF
--- a/building/upload-debs/rebuild-apt-bootstrap.sh
+++ b/building/upload-debs/rebuild-apt-bootstrap.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e -u
+
+if [ "${KUID:-}" = "" ]
+then
+    echo "KUID expected."
+    exit 1
+fi
+
+cd "$(dirname "$0")"
+VERSION="$(dpkg-parsechangelog -l"../build-debs/homeworld-apt-setup/debian/changelog" -S Version)"
+DEB="../build-debs/binaries/homeworld-apt-setup_${VERSION}_amd64.deb"
+cp "${DEB}" /mit/hyades/homeworld-apt-setup.deb
+"${GPG:-gpg}" --detach-sign --armor --local-user "${KUID}" "${DEB}" >/mit/hyades/homeworld-apt-setup.deb.asc
+
+echo "signed!"

--- a/building/upload-debs/rebuild.sh
+++ b/building/upload-debs/rebuild.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e -u
 
 cd "$(dirname "$0")"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,6 +9,8 @@ To set up the apt repository:
           DELETE YOUR DOWNLOADS AND DO NOT CONTINUE
     $ sudo dpkg -i homeworld-apt-setup.deb
 
+(You can also just build homeworld-apt-setup yourself.)
+
 To install homeworld-admin-tools:
 
     $ sudo apt-get update

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,9 +1,20 @@
 # Installing packages
 
-You will need to install homeworld-admin-tools and all its dependencies. This
-will provide access to the 'spire' tool.
+To set up the apt repository:
 
-TODO: instructions on setting this up.
+    $ wget http://web.mit.edu/hyades/homeworld-apt-setup.deb
+    $ wget http://web.mit.edu/hyades/homeworld-apt-setup.deb.asc
+    $ gpg --verify homeworld-apt-setup.deb.asc
+       ^^ IF THIS FAILS (or you haven't verified cela's key in person before),
+          DELETE YOUR DOWNLOADS AND DO NOT CONTINUE
+    $ sudo dpkg -i homeworld-apt-setup.deb
+
+To install homeworld-admin-tools:
+
+    $ sudo apt-get update
+    $ sudo apt-get install homeworld-admin-tools
+
+This will provide access to the 'spire' tool.
 
 # Setting up a new cluster from scratch
 


### PR DESCRIPTION
This adds a signed upload to make it easier to install homeworld-apt-setup and then use the normal repository tools.

~Merging is blocked on #135.~

Fixes #142.