### PR TITLE
Add whois as spire dependency

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.23) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Mark Theng <mtheng@mit.edu>  Sat, 16 Dec 2017 16:22:07 -0500
+
 homeworld-admin-tools (0.1.22) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/debian/control
+++ b/building/build-debs/homeworld-admin-tools/debian/control
@@ -9,6 +9,6 @@ Vcs-Browser: https://github.com/sipb/homeworld/
 
 Package: homeworld-admin-tools
 Architecture: amd64
-Depends: ${misc:Depends}, homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, libarchive-tools | bsdtar, python3, python3-yaml, pwgen, genisoimage
+Depends: ${misc:Depends}, homeworld-keysystem, homeworld-hyperkube, homeworld-etcd, libarchive-tools | bsdtar, python3, python3-yaml, pwgen, genisoimage, whois
 Description: Homeworld admin-tools package.
  This package is used for code deployment to Homeworld clusters.


### PR DESCRIPTION
Spire uses mkpasswd, which is part of the whois package.