### PR TITLE
WIP: Add .encrypted to filename of encrypted authority keys.

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.27) stretch; urgency=medium
+
+  * Updated debian release.
+
+ -- Matthew Ince <3cnfsat@gmail.com>  Sun, 17 Dec 2017 18:07:47 -0500
+
 homeworld-admin-tools (0.1.26) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/src/authority.py
+++ b/building/build-debs/homeworld-admin-tools/src/authority.py
@@ -16,13 +16,13 @@ def get_targz_path(check_exists=True):
         command.fail("authorities.tgz does not exist (run spire authority gen?)")
     return authorities
 
-def encrypted_name(filename):
+def name_for_encrypted_file(filename):
     return filename + ENCRYPTED_EXTENSION
 
-def decrypted_name(encrypted_filename):
-    if encrypted_filename.endswith(ENCRYPTED_EXTENSION):
-        return encrypted_filename[:-len(ENCRYPTED_EXTENSION)]
-    raise ValueError("Filename " + encrypted_filename + " does not have expected suffix '" + ENCRYPTED_EXTENSION + "'.")
+def name_for_decrypted_file(name_of_encrypted_file):
+    if name_of_encrypted_file.endswith(ENCRYPTED_EXTENSION):
+        return name_of_encrypted_file[:-len(ENCRYPTED_EXTENSION)]
+    raise ValueError("Filename " + name_of_encrypted_file + " does not have expected suffix '" + ENCRYPTED_EXTENSION + "'.")
     
 def generate() -> None:
     authorities = get_targz_path(check_exists=False)
@@ -87,7 +87,7 @@ def iterate_keys_decrypted():  # yields (name, contents) pairs
         if name.endswith(".pub") or name.endswith(".pem"):
             yield name, contents
         else:
-            yield decrypted_name(name), keycrypt.gpg_decrypt_in_memory(contents)
+            yield name_for_decrypted_file(name), keycrypt.gpg_decrypt_in_memory(contents)
 
 
 main_command = command.mux_map("commands about cluster authorities", {

--- a/building/build-debs/homeworld-admin-tools/src/authority.py
+++ b/building/build-debs/homeworld-admin-tools/src/authority.py
@@ -15,7 +15,9 @@ def get_targz_path(check_exists=True):
         command.fail("authorities.tgz does not exist (run spire authority gen?)")
     return authorities
 
-
+def encrypted_name(filename):
+    return filename + ".encrypted"
+    
 def generate() -> None:
     authorities = get_targz_path(check_exists=False)
     if os.path.exists(authorities):
@@ -44,7 +46,7 @@ def generate() -> None:
                 util.copy(os.path.join(certdir, filename), os.path.join(cryptdir, filename))
             else:
                 # private keys; encrypt when copying
-                keycrypt.gpg_encrypt_file(os.path.join(certdir, filename), os.path.join(cryptdir, filename))
+                keycrypt.gpg_encrypt_file(os.path.join(certdir, filename), os.path.join(cryptdir, encrypted_name(filename)))
         subprocess.check_call(["shred", "--"] + os.listdir(certdir), cwd=certdir)
         print("packing authorities...")
         subprocess.check_call(["tar", "-C", cryptdir, "-czf", authorities, "."])
@@ -59,7 +61,6 @@ def get_pubkey_by_filename(keyname) -> bytes:
             out = f.read()
             assert type(out) == bytes
             return out
-
 
 def iterate_keys():  # yields (name, contents) pairs
     authorities = get_targz_path()

--- a/building/build-debs/homeworld-admin-tools/src/authority.py
+++ b/building/build-debs/homeworld-admin-tools/src/authority.py
@@ -52,7 +52,7 @@ def generate() -> None:
                 util.copy(os.path.join(certdir, filename), os.path.join(cryptdir, filename))
             else:
                 # private keys; encrypt when copying, and rename encrypted version for clarity.
-                keycrypt.gpg_encrypt_file(os.path.join(certdir, filename), os.path.join(cryptdir, encrypted_name(filename)))
+                keycrypt.gpg_encrypt_file(os.path.join(certdir, filename), os.path.join(cryptdir, name_for_encrypted_file(filename)))
         subprocess.check_call(["shred", "--"] + os.listdir(certdir), cwd=certdir)
         print("packing authorities...")
         subprocess.check_call(["tar", "-C", cryptdir, "-czf", authorities, "."])


### PR DESCRIPTION
This pull request addresses issue #130. Testing done: rebuilt Spire and ran "spire authority gen" without incident. Future testing: full deployment of development Hyades cluster.
  
Additionally, tested new functions via interactive python terminal:

>>> name_for_encrypted_file('blah.key')
'blah.key.encrypted'
>>> name_for_decrypted_file('blah.key')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in name_for_decrypted_file
ValueError: Filename blah.key does not have expected suffix '.encrypted'.
>>> name_for_decrypted_file('blah.key.encrypted')
'blah.key'

 Installed my version of Spire via

$ sudo dpkg -i ../binaries/homeworld-admin-tools_0.1.27_amd64.deb 

and ran a full build and deploy.

Also checked that authorities had proper names:

minced@minced-ThinkPad-Yoga-11e:~/hyades-cluster$ tar -tf authorities.tgz 
./
./server.pem
./etcd-server.pem
./ssh_user_ca.encrypted
./kubernetes.key.encrypted
./keygrant.key.encrypted
./ssh_user_ca.pub
./etcd-server.key.encrypted
./ssh_host_ca.encrypted
./ssh_host_ca.pub
./server.key.encrypted
./etcd-client.pem
./kubernetes.pem
./keygrant.pem
./serviceaccount.key.encrypted
./etcd-client.key.encrypted
./serviceaccount.pem