### PR TITLE
Handle error with ssh-add when gnome-keyring is used

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.26) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Mark Theng <mtheng@mit.edu>  Sun, 31 Dec 2017 15:52:30 -0500
+
 homeworld-admin-tools (0.1.25) stretch; urgency=medium
 
   * Updated debian release


### PR DESCRIPTION
As per #159. It's a rather ugly way to handle the bug, but then it's a rather ugly bug.