### PR TITLE
Add the current Git commit to the ISO

### DIFF
--- a/building/build-debs/homeworld-admin-tools/resources/postinstall.sh
+++ b/building/build-debs/homeworld-admin-tools/resources/postinstall.sh
@@ -2,6 +2,7 @@
 echo "launching postinstall"
 
 BUILDDATE="$1"
+GIT_HASH="$2"
 
 . /usr/share/debconf/confmodule
 
@@ -10,6 +11,12 @@ set -e -u
 if [ "$BUILDDATE" = "" ]
 then
     echo "invalid build date" 1>&2
+    exit 1
+fi
+
+if [ "$GIT_HASH" = "" ]
+then
+    echo "invalid git hash" 1>&2
     exit 1
 fi
 
@@ -58,6 +65,7 @@ then
 fi
 
 echo "ISO used to install this node generated at: ${BUILDDATE}" >>/target/etc/issue
+echo "Git commit used to build the version: ${GIT_HASH}" >>/target/etc/issue
 echo "SSH host key fingerprints: (as of install)" >>/target/etc/issue
 for x in /target/etc/ssh/ssh_host_*.pub
 do

--- a/building/build-debs/homeworld-admin-tools/resources/preseed.cfg.in
+++ b/building/build-debs/homeworld-admin-tools/resources/preseed.cfg.in
@@ -433,4 +433,4 @@ d-i apt-setup/cdrom/set-next boolean false
 # packages and run commands in the target system.
 #d-i preseed/late_command string apt-install zsh; in-target chsh -s /bin/zsh
 
-d-i preseed/late_command string /postinstall.sh {{BUILDDATE}}
+d-i preseed/late_command string /postinstall.sh {{BUILDDATE}} {{GITHASH}}

--- a/building/build-debs/homeworld-admin-tools/src/iso.py
+++ b/building/build-debs/homeworld-admin-tools/src/iso.py
@@ -10,6 +10,7 @@ import subprocess
 import util
 import packages
 import keycrypt
+from version import get_git_version
 
 PACKAGES = ("homeworld-apt-setup", "homeworld-knc", "homeworld-keysystem")
 
@@ -69,9 +70,12 @@ def gen_iso(iso_image, authorized_key, cdpack=None):
         preseeded = resource.get_resource("preseed.cfg.in")
         generated_password = util.pwgen(20)
         creation_time = datetime.datetime.now().isoformat()
+        git_hash = get_git_version().encode()
         add_password_to_log(generated_password, creation_time)
         print("generated password added to log")
-        preseeded = preseeded.replace(b"{{HASH}}", util.mkpasswd(generated_password)).replace(b"{{BUILDDATE}}", creation_time.encode())
+        preseeded = preseeded.replace(b"{{HASH}}", util.mkpasswd(generated_password))
+        preseeded = preseeded.replace(b"{{BUILDDATE}}", creation_time.encode())
+        preseeded = preseeded.replace(b"{{GITHASH}}", git_hash);
         util.writefile(os.path.join(d, "preseed.cfg"), preseeded)
 
         inclusion += ["sshd_config.new", "preseed.cfg"]

--- a/building/build-debs/homeworld-admin-tools/src/version.py
+++ b/building/build-debs/homeworld-admin-tools/src/version.py
@@ -3,11 +3,15 @@ import command
 from resources import get_resource
 
 
+def get_git_version():
+    return get_resource("GIT_VERSION").decode().rstrip()
+
+
 def display_version():
     deb_version = get_resource("DEB_VERSION").decode().rstrip()
     print("Debian package version:", deb_version)
 
-    git_version = get_resource("GIT_VERSION").decode().rstrip()
+    git_version = get_git_version()
     print("Git commit hash:", git_version)
 
 


### PR DESCRIPTION
This PR addresses the new concern in issue #155.

This commit does the following:
* Adds the hash of the current git HEAD to the preseed.cfg file.
* Adds a required option for the Git commit hash used to build the issue to the ISO's postinstall script
* The postinstall script writes a new line to the /etc/issue file of the new install, containing the commit hash used