### PR TITLE
Add code to have the user re-confirm the bootstrap token

### DIFF
--- a/building/build-debs/homeworld-admin-tools/src/infra.py
+++ b/building/build-debs/homeworld-admin-tools/src/infra.py
@@ -18,10 +18,10 @@ def infra_admit_all() -> None:
         principal = node.hostname + "." + config.external_domain
         token = access.call_keyreq("bootstrap-token", principal, collect=True).decode().strip()
         tokens[node.hostname] = (node.kind, node.ip, token)
-    print("host".center(16, "="), "kind".center(8, "="), "ip".center(14, "="), "token".center(21, "="))
+    print("host".center(16, "="), "kind".center(8, "="), "ip".center(14, "="), "token".center(23, "="))
     for key, (kind, ip, token) in sorted(tokens.items()):
-        print(key.rjust(16), kind.center(8), str(ip).center(14), token.ljust(21))
-    print("host".center(16, "="), "kind".center(8, "="), "ip".center(14, "="), "token".center(21, "="))
+        print(key.rjust(16), kind.center(8), str(ip).center(14), token.ljust(23))
+    print("host".center(16, "="), "kind".center(8, "="), "ip".center(14, "="), "token".center(23, "="))
 
 
 def infra_install_packages(ops: setup.Operations) -> None:

--- a/building/build-debs/homeworld-keysystem/src/keyserver/token/scoped/token.go
+++ b/building/build-debs/homeworld-keysystem/src/keyserver/token/scoped/token.go
@@ -2,6 +2,7 @@ package scoped
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"sync"
@@ -37,7 +38,10 @@ func generateTokenID() string {
 	if err != nil {
 		panic(err)
 	}
-	return base64.RawStdEncoding.EncodeToString(out)
+
+	hash := base64.RawStdEncoding.EncodeToString(out)
+	hashSha256 := sha256.Sum256([]byte(hash))
+	return hash + base64.RawStdEncoding.EncodeToString(hashSha256[:])[0:2]
 }
 
 func GenerateToken(subject string, duration time.Duration) ScopedToken {

--- a/building/build-debs/homeworld-keysystem/src/keyserver/token/scoped/token_test.go
+++ b/building/build-debs/homeworld-keysystem/src/keyserver/token/scoped/token_test.go
@@ -1,6 +1,8 @@
 package scoped
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"math"
 	"math/rand"
 	"strings"
@@ -36,8 +38,21 @@ func TestTokensArePrintable(t *testing.T) {
 func TestTokensLength(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		token := generateTokenID()
-		if len(token) != 20 {
+		if len(token) != 22 {
 			t.Errorf("Incorrect token length %d (expected %d)", len(token), 22)
+		}
+	}
+}
+
+func TestTokensHaveValidFormat(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		rawToken := generateTokenID()
+		hashOnToken := rawToken[len(rawToken)-2 : len(rawToken)]
+		actualToken := rawToken[0 : len(rawToken)-2]
+		hashExpectedBytes := sha256.Sum256([]byte(actualToken))
+		hashExpected := base64.RawStdEncoding.EncodeToString(hashExpectedBytes[:])[0:2]
+		if hashOnToken != hashExpected {
+			t.Errorf("Incorrect token hash found \"%s\" (expecting \"%s\")\n%s\n%s", hashOnToken, hashExpected, rawToken, actualToken)
 		}
 	}
 }
@@ -146,7 +161,7 @@ func TestGenerateToken(t *testing.T) {
 	if token.Subject != "my-subject" {
 		t.Errorf("Inaccurately represented subject name")
 	}
-	if len(token.Token) != 20 {
+	if len(token.Token) != 22 {
 		t.Errorf("Used invalid token name in generated token")
 	}
 }


### PR DESCRIPTION
This PR addresses #132 

Currently, the user only has to type the bootstrap token once, which is quite vulnerable to someone making a typo. This PR forces the bootstrap token to typed at least twice, if the tokens do not match then the installer will continue to prompt for the bootstrap tokens until they do match.