### PR TITLE
Fix spire compilation with inner-build.sh

### DIFF
--- a/building/build-debs/homeworld-admin-tools/inner-build.sh
+++ b/building/build-debs/homeworld-admin-tools/inner-build.sh
@@ -18,6 +18,14 @@ then
     echo >>src/resources/GIT_VERSION
 fi
 
+if [[ ! -e src/resources/APT_BRANCH ]]
+then
+    source ../../setup-apt-branch/setup-apt-branch.sh
+    echo "${HOMEWORLD_APT_BRANCH}" >src/resources/APT_BRANCH
+    HOMEWORLD_APT_SIGNING_KEY="$(get_apt_signing_key)"
+    gpg --export "${HOMEWORLD_APT_SIGNING_KEY}" >src/resources/homeworld-archive-keyring.gpg
+fi
+
 (cd src && zip -r ../spire.zip *)
 
 python3 spire.zip iso regen-cdpack debian-9.2.0-amd64-mini.iso src/resources/debian-9.2.0-cdpack.tgz

--- a/building/setup-apt-branch/setup-apt-branch.sh
+++ b/building/setup-apt-branch/setup-apt-branch.sh
@@ -2,6 +2,7 @@ if [ -z "${HOMEWORLD_APT_BRANCH:-}" ]
 then
 	echo 'Error: Need to specify apt branch:' >&2
 	echo '$ export HOMEWORLD_APT_BRANCH=<username>/<branch>' >&2
+	echo 'Use root/master if you would like to base this off the main repository.' >&2
 	exit 1
 fi
 


### PR DESCRIPTION
Fixes #217. Rather than handling it within spire, this just includes the relevant resources during inner-build with duplicated code, in the same manner as GIT_VERSION. I haven't found a way to pass environment variables into sbuild, but if the duplicated code is a problem, it should be possible to bypass this by creating a separate build endpoint for quick compilation without the chroot.