### PR TITLE
Use argparse for argument parsing

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.41) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Mark Theng <mtheng@mit.edu>  Mon, 29 Jan 2018 15:52:39 -0500
+
 homeworld-admin-tools (0.1.40) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/src/__main__.py
+++ b/building/build-debs/homeworld-admin-tools/src/__main__.py
@@ -34,4 +34,4 @@ main_command = command.mux_map("invoke a top-level command", {
 
 
 if __name__ == "__main__":
-    sys.exit(command.main_invoke(main_command, sys.argv[1:]))
+    sys.exit(command.main_invoke(main_command))

--- a/building/build-debs/homeworld-admin-tools/src/seq.py
+++ b/building/build-debs/homeworld-admin-tools/src/seq.py
@@ -1,4 +1,5 @@
 import time
+import argparse
 
 import access
 import command
@@ -15,15 +16,11 @@ def sequence_keysystem(ops: setup.Operations) -> None:
     ops.add_subcommand(setup.setup_keygateway)
     ops.add_operation("verify that the keygateway is responsive", verify.check_keygateway)
 
-    ops.print_annotations("set up the keysystem")
-
 
 def sequence_ssh(ops: setup.Operations) -> None:
     ops.add_operation("request SSH access to cluster", access.access_ssh_with_add)
     ops.add_subcommand(setup.setup_supervisor_ssh)
     ops.add_operation("verify ssh access to supervisor", iterative_verifier(verify.check_ssh_with_certs, 20.0))
-
-    ops.print_annotations("set up ssh")
 
 
 def sequence_supervisor(ops: setup.Operations) -> None:
@@ -37,8 +34,6 @@ def sequence_supervisor(ops: setup.Operations) -> None:
     ops.add_operation("pre-deploy dns-addon", deploy.launch_dns_addon)
     ops.add_operation("pre-deploy flannel-monitor", deploy.launch_flannel_monitor)
     ops.add_operation("pre-deploy dns-monitor", deploy.launch_dns_monitor)
-
-    ops.print_annotations("set up the supervisor")
 
 
 def iterative_verifier(verifier, max_time, pause=2.0):
@@ -55,8 +50,8 @@ def iterative_verifier(verifier, max_time, pause=2.0):
                 print("RETRYING...")
             time.sleep(pause)
 
-    ver.dispatch_set_name = lambda name: command.provide_command_for_function(verifier, name)
-    ver.dispatch_get_name = lambda default: command.get_command_for_function(verifier, default)
+    command.provide_command_for_function(ver, command.get_command_for_function(verifier))
+    ver.dispatch_get_name = lambda default: command.get_command_for_function(verifier)
 
     return ver
 
@@ -76,13 +71,47 @@ def sequence_cluster(ops: setup.Operations) -> None:
     ops.add_operation("verify that flannel is online", iterative_verifier(verify.check_flannel, 180.0))
     ops.add_operation("verify that dns-addon is online", iterative_verifier(verify.check_dns, 120.0))
 
-    ops.print_annotations("set up the kubernetes cluster")
+
+def add_dry_run_argument(parser: argparse.ArgumentParser, dest: str):
+    parser.add_argument("--dry-run", dest=dest, action="store_true", help="show command sequence performed by command without actually running them")
 
 
-main_command = command.mux_map("commands about running large sequences of cluster bring-up automatically", {
-    "keysystem": setup.wrapop("set up and verify functionality of the keyserver and keygateway", sequence_keysystem),
-    "ssh": setup.wrapop("set up and verify ssh access to the supervisor node", sequence_ssh),
-    "supervisor": setup.wrapop("set up and verify functionality of entire supervisor node (keysystem + ssh)",
+def wrapseq(desc: str, f):
+    def wrap_param_tx(args):
+        ops = setup.Operations()
+
+        def invoke():
+            if args.dry_run or args.dry_run_outer:
+                ops.print_annotations()
+            else:
+                ops.run_operations()
+
+        return [ops] + args.params, invoke
+
+    desc, inner_configure = command.wrap(desc, f, wrap_param_tx)
+
+    def configure(command: list, parser: argparse.ArgumentParser):
+        add_dry_run_argument(parser, "dry_run")
+        inner_configure(command, parser)
+
+    return desc, configure
+
+
+def seq_mux_map(desc, mapping):
+    desc, inner_configure = command.mux_map(desc, mapping)
+
+    def configure(command: list, parser: argparse.ArgumentParser):
+        # allow --dry-run to be present before selector and also have it appear in the help message
+        add_dry_run_argument(parser, "dry_run_outer")
+        inner_configure(command, parser)
+
+    return desc, configure
+
+
+main_command = seq_mux_map("commands about running large sequences of cluster bring-up automatically", {
+    "keysystem": wrapseq("set up and verify functionality of the keyserver and keygateway", sequence_keysystem),
+    "ssh": wrapseq("set up and verify ssh access to the supervisor node", sequence_ssh),
+    "supervisor": wrapseq("set up and verify functionality of entire supervisor node (keysystem + ssh)",
                                sequence_supervisor),
-    "cluster": setup.wrapop("set up and verify kubernetes infrastructure operation", sequence_cluster),
+    "cluster": wrapseq("set up and verify kubernetes infrastructure operation", sequence_cluster),
 })

--- a/building/build-debs/homeworld-admin-tools/src/setup.py
+++ b/building/build-debs/homeworld-admin-tools/src/setup.py
@@ -35,15 +35,14 @@ class Operations:
         self._ignore_annotations -= 1
 
     def annotate_from(self, func):
-        self.annotate_subcommand(command.get_command_for_function(func, default="<unannotated subcommand: %s>" % func))
+        self.annotate_subcommand(command.get_command_for_function(func))
 
     def annotate_subcommand(self, command):
         if not self._ignore_annotations:
-            self._annotations.append("$ " + command)
+            self._annotations.append("$ " + " ".join(command))
 
-    def print_annotations(self, purpose):
+    def print_annotations(self):
         if not self._ignore_annotations:
-            print("commands being executed to %s:" % purpose)
             for annotation in self._annotations:
                 print("  %s" % annotation)
 
@@ -233,9 +232,9 @@ def setup_prometheus(ops: Operations) -> None:
 
 
 def wrapop(desc: str, f):
-    def wrap_param_tx(params):
+    def wrap_param_tx(args):
         ops = Operations()
-        return [ops] + params, ops.run_operations
+        return [ops] + args.params, ops.run_operations
     return command.wrap(desc, f, wrap_param_tx)
 
 

--- a/building/build-debs/homeworld-admin-tools/src/verify.py
+++ b/building/build-debs/homeworld-admin-tools/src/verify.py
@@ -211,6 +211,7 @@ main_command = command.mux_map("commands about verifying the state of a cluster"
     "keygateway": command.wrap("verify that the keygateway has been properly started", check_keygateway),
     "online": command.wrap("check whether a server (or all servers) is/are accepting SSH connections", check_online),
     "ssh-with-certs": command.wrap("check if certificate-based SSH access works", check_ssh_with_certs),
+    "supervisor-certs": command.wrap("verify that certificates have been uploaded to the supervisor", check_certs_on_supervisor),
     "etcd": command.wrap("verify that etcd is healthy and working", check_etcd_health),
     "kubernetes-init": command.wrap("verify that kubernetes appears initialized", check_kube_init),
     "kubernetes": command.wrap("verify that kubernetes appears healthy", check_kube_health),


### PR DESCRIPTION
Fixes #181 and #182. I had it no longer print the command sequence during the actual run, since it can be easily accessed with --dry-run anyway.

Also adds a manual command for checking supervisor certs (bug found during testing).