### PR TITLE
Fix 257: specify bridge to avoid losing traffic from the outside world

### DIFF
--- a/building/build-debs/homeworld-services/10-containernet.conf
+++ b/building/build-debs/homeworld-services/10-containernet.conf
@@ -2,6 +2,7 @@
 	"name": "rkt.kubernetes.io",
 	"type": "flannel",
 	"delegate": {
-		"isDefaultGateway": true
+		"isDefaultGateway": true,
+		"bridge": "homeworld-cni0"
 	}
 }

--- a/building/build-debs/homeworld-services/debian/changelog
+++ b/building/build-debs/homeworld-services/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-services (0.1.32) stretch; urgency=medium
+
+  * Updated debian version
+
+ -- Cel Skeggs <cela@mit.edu>  Sat, 17 Feb 2018 13:09:48 -0500
+
 homeworld-services (0.1.31) stretch; urgency=medium
 
   * Updated debian version


### PR DESCRIPTION
Previously, the bridge generated by flannel would be cni0 if launched under the
coreos stage1, and kvm-cni0 if launched under the kvm stage1. Since both had
the same subnet bound, this would cause a conflict where traffic could only be
delivered to one of the two.

This change specifies that the bridge should always be homeworld-cni0, so that
the two stage1s will agree on the CNI bridge to use.