### PR TITLE
Add command to run a command across all nodes of a given type

### DIFF
--- a/building/build-debs/homeworld-admin-tools/src/__main__.py
+++ b/building/build-debs/homeworld-admin-tools/src/__main__.py
@@ -26,6 +26,7 @@ main_command = command.mux_map("invoke a top-level command", {
     "access": access.main_command,
     "etcdctl": access.etcdctl_command,
     "kubectl": access.kubectl_command,
+    "foreach": access.foreach_command,
     "infra": infra.main_command,
     "seq": seq.main_command,
     "deploy": deploy.main_command,


### PR DESCRIPTION
get_kube_cert_paths was shuffled to get rid of the circular import.