### PR TITLE
More descriptive error messages from keyreq and spire

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.49) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Mark Theng <mtheng@mit.edu>  Sat, 17 Feb 2018 21:27:08 -0500
+
 homeworld-admin-tools (0.1.48) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/src/access.py
+++ b/building/build-debs/homeworld-admin-tools/src/access.py
@@ -77,7 +77,7 @@ def diagnose_keyreq_error(errcode: int, err: str) -> Tuple[str, str]:
     return error_code_meaning, None
 
 
-def call_keyreq(keyreq_command, *params, collect=False):
+def call_keyreq(keyreq_command, *params):
     config = configuration.get_config()
     keyserver_domain = config.keyserver.hostname + "." + config.external_domain + ":20557"
 

--- a/building/build-debs/homeworld-admin-tools/src/infra.py
+++ b/building/build-debs/homeworld-admin-tools/src/infra.py
@@ -7,7 +7,7 @@ import setup
 def infra_admit(server_principal: str) -> None:
     config = configuration.get_config()
     principal_hostname = config.get_fqdn(server_principal)
-    token = access.call_keyreq("bootstrap-token", principal_hostname, collect=True)
+    token = access.call_keyreq("bootstrap-token", principal_hostname)
     print("Token granted for %s: '%s'" % (server_principal, token.decode().strip()))
 
 
@@ -18,7 +18,7 @@ def infra_admit_all() -> None:
         if node.kind == "supervisor":
             continue
         principal = node.hostname + "." + config.external_domain
-        token = access.call_keyreq("bootstrap-token", principal, collect=True).decode().strip()
+        token = access.call_keyreq("bootstrap-token", principal).decode().strip()
         tokens[node.hostname] = (node.kind, node.ip, token)
     print("host".center(16, "="), "kind".center(8, "="), "ip".center(14, "="), "token".center(23, "="))
     for key, (kind, ip, token) in sorted(tokens.items()):

--- a/building/build-debs/homeworld-keysystem/debian/changelog
+++ b/building/build-debs/homeworld-keysystem/debian/changelog
@@ -1,32 +1,8 @@
-homeworld-keysystem (0.1.21) stretch; urgency=medium
-
-  * Update debian version
-
- -- Mark Theng <mtheng@mit.edu>  Sat, 17 Feb 2018 20:14:58 -0500
-
-homeworld-keysystem (0.1.20) stretch; urgency=medium
-
-  * Update debian version
-
- -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 16:39:05 -0500
-
-homeworld-keysystem (0.1.19) stretch; urgency=medium
-
-  * Update debian version
-
- -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 16:27:32 -0500
-
-homeworld-keysystem (0.1.18) stretch; urgency=medium
-
-  * Update debian version
-
- -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 15:38:58 -0500
-
 homeworld-keysystem (0.1.17) stretch; urgency=medium
 
   * Update debian version
 
- -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 15:15:39 -0500
+ -- Mark Theng <mtheng@mit.edu>  Sat, 17 Feb 2018 20:14:58 -0500
 
 homeworld-keysystem (0.1.16) stretch; urgency=medium
 

--- a/building/build-debs/homeworld-keysystem/debian/changelog
+++ b/building/build-debs/homeworld-keysystem/debian/changelog
@@ -1,3 +1,33 @@
+homeworld-keysystem (0.1.21) stretch; urgency=medium
+
+  * Update debian version
+
+ -- Mark Theng <mtheng@mit.edu>  Sat, 17 Feb 2018 20:14:58 -0500
+
+homeworld-keysystem (0.1.20) stretch; urgency=medium
+
+  * Update debian version
+
+ -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 16:39:05 -0500
+
+homeworld-keysystem (0.1.19) stretch; urgency=medium
+
+  * Update debian version
+
+ -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 16:27:32 -0500
+
+homeworld-keysystem (0.1.18) stretch; urgency=medium
+
+  * Update debian version
+
+ -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 15:38:58 -0500
+
+homeworld-keysystem (0.1.17) stretch; urgency=medium
+
+  * Update debian version
+
+ -- Cel Skeggs <cela@mit.edu>  Fri, 02 Feb 2018 15:15:39 -0500
+
 homeworld-keysystem (0.1.16) stretch; urgency=medium
 
   * Update debian version

--- a/building/build-debs/homeworld-keysystem/src/keyreq/main/keyreq.go
+++ b/building/build-debs/homeworld-keysystem/src/keyreq/main/keyreq.go
@@ -13,14 +13,24 @@ import (
 	"util/csrutil"
 )
 
+const (
+	ERR_UNKNOWN_FAILURE = 1
+	ERR_CANNOT_ESTABLISH_CONNECTION = 2
+	ERR_NO_ACCESS = 3
+	ERR_INVALID_CONFIG = 254
+	ERR_INVALID_INVOCATION = 255
+)
+
 func get_keyserver(logger *log.Logger, authority_path string, keyserver_domain string) *server.Keyserver {
 	authoritydata, err := ioutil.ReadFile(authority_path)
 	if err != nil {
-		logger.Fatalf("while loading authority: %s", err)
+		logger.Printf("while loading authority: %s", err)
+		os.Exit(ERR_INVALID_INVOCATION)
 	}
 	ks, err := server.NewKeyserver(authoritydata, keyserver_domain)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Print(err)
+		os.Exit(ERR_INVALID_CONFIG)
 	}
 	return ks
 }
@@ -29,12 +39,14 @@ func auth_kerberos(logger *log.Logger, authority_path string, keyserver_domain s
 	ks := get_keyserver(logger, authority_path, keyserver_domain)
 	rt, err := ks.AuthenticateWithKerberosTickets()
 	if err != nil {
-		logger.Fatal(err)
+		logger.Print(err)
+		os.Exit(ERR_INVALID_INVOCATION)
 	}
 	// confirm that connection works
 	_, err = rt.SendRequests([]reqtarget.Request{})
 	if err != nil {
-		logger.Fatal("failed to check connection: ", err)
+		logger.Print("failed to establish connection: ", err)
+		os.Exit(ERR_CANNOT_ESTABLISH_CONNECTION)
 	}
 	return ks, rt
 }
@@ -42,125 +54,149 @@ func auth_kerberos(logger *log.Logger, authority_path string, keyserver_domain s
 func main() {
 	logger := log.New(os.Stderr, "[keyreq] ", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
 	if len(os.Args) < 2 {
-		logger.Fatal("keyreq should only be used by scripts that already know how to invoke it")
-		return
+		logger.Print("keyreq should only be used by scripts that already know how to invoke it")
+		os.Exit(ERR_INVALID_INVOCATION)
 	}
 	switch os.Args[1] {
 	case "check":
 		if len(os.Args) < 4 {
-			logger.Fatal("not enough parameters to keyreq check <authority-path> <keyserver-domain>")
+			logger.Print("not enough parameters to keyreq check <authority-path> <keyserver-domain>")
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		// just by calling this, we confirm that we do have access to the server. yay!
 		_, _ = auth_kerberos(logger, os.Args[2], os.Args[3])
 	case "ssh-cert": // called programmatically
 		if len(os.Args) < 6 {
-			logger.Fatal("not enough parameters to keyreq ssh-cert <authority-path> <keyserver-domain> <ssh.pub-in> <ssh-cert-output>")
+			logger.Print("not enough parameters to keyreq ssh-cert <authority-path> <keyserver-domain> <ssh.pub-in> <ssh-cert-output>")
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
-		_, rt := auth_kerberos(logger, os.Args[2], os.Args[3])
 		ssh_pubkey, err := ioutil.ReadFile(os.Args[4])
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
+		_, rt := auth_kerberos(logger, os.Args[2], os.Args[3])
 		req, err := reqtarget.SendRequest(rt, "access-ssh", string(ssh_pubkey))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_NO_ACCESS)
 		}
 		if req == "" {
-			logger.Fatal("empty result")
+			logger.Print("empty result")
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		err = ioutil.WriteFile(os.Args[5], []byte(req), os.FileMode(0644))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 	case "kube-cert":
 		if len(os.Args) < 7 {
-			logger.Fatal("not enough parameters to keyreq kube-cert <authority-path> <keyserver-domain> <privkey-out> <cert-out> <ca-out>")
-			return
+			logger.Print("not enough parameters to keyreq kube-cert <authority-path> <keyserver-domain> <privkey-out> <cert-out> <ca-out>")
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		ks, rt := auth_kerberos(logger, os.Args[2], os.Args[3])
 		pkey, err := rsa.GenerateKey(rand.Reader, 2048) // smaller key sizes are okay, because these are limited to a short period
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		privkey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pkey)})
 		csr, err := csrutil.BuildTLSCSR(privkey)
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		req, err := reqtarget.SendRequest(rt, "access-kubernetes", string(csr))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_NO_ACCESS)
 		}
 		if req == "" {
-			logger.Fatal("empty result")
+			logger.Print("empty result")
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		err = ioutil.WriteFile(os.Args[4], privkey, os.FileMode(0600))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		err = ioutil.WriteFile(os.Args[5], []byte(req), os.FileMode(0644))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		ca, err := ks.GetPubkey("kubernetes")
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_CANNOT_ESTABLISH_CONNECTION)
 		}
 		err = ioutil.WriteFile(os.Args[6], ca, os.FileMode(0644))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 	case "etcd-cert":
 		// TODO: deduplicate code
 		if len(os.Args) < 7 {
-			logger.Fatal("not enough parameters to keyreq etcd-cert <authority-path> <keyserver-domain> <privkey-out> <cert-out> <ca-out>")
-			return
+			logger.Print("not enough parameters to keyreq etcd-cert <authority-path> <keyserver-domain> <privkey-out> <cert-out> <ca-out>")
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		ks, rt := auth_kerberos(logger, os.Args[2], os.Args[3])
 		pkey, err := rsa.GenerateKey(rand.Reader, 2048) // smaller key sizes are okay, because these are limited to a short period
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		privkey := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pkey)})
 		csr, err := csrutil.BuildTLSCSR(privkey)
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		req, err := reqtarget.SendRequest(rt, "access-etcd", string(csr))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_NO_ACCESS)
 		}
 		if req == "" {
-			logger.Fatal("empty result")
+			logger.Print("empty result")
+			os.Exit(ERR_UNKNOWN_FAILURE)
 		}
 		err = ioutil.WriteFile(os.Args[4], privkey, os.FileMode(0600))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		err = ioutil.WriteFile(os.Args[5], []byte(req), os.FileMode(0644))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		ca, err := ks.GetPubkey("etcd-server")
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_CANNOT_ESTABLISH_CONNECTION)
 		}
 		err = ioutil.WriteFile(os.Args[6], ca, os.FileMode(0644))
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 	case "bootstrap-token":
 		if len(os.Args) < 5 {
-			logger.Fatal("not enough parameters to keyreq bootstrap-token <authority-path> <keyserver-domain> <principal>")
-			return
+			logger.Print("not enough parameters to keyreq bootstrap-token <authority-path> <keyserver-domain> <principal>")
+			os.Exit(ERR_INVALID_INVOCATION)
 		}
 		_, rt := auth_kerberos(logger, os.Args[2], os.Args[3])
 		token, err := reqtarget.SendRequest(rt, "bootstrap", os.Args[4])
 		if err != nil {
-			logger.Fatal(err)
+			logger.Print(err)
+			os.Exit(ERR_NO_ACCESS)
 		}
 		os.Stdout.WriteString(token + "\n")
 	default:
-		logger.Fatal("keyreq should only be used by scripts that already know how to invoke it")
+		logger.Print("keyreq should only be used by scripts that already know how to invoke it")
+		os.Exit(ERR_INVALID_INVOCATION)
 	}
 }

--- a/building/build-debs/sources-shared/src/keycommon/knc/knc.go
+++ b/building/build-debs/sources-shared/src/keycommon/knc/knc.go
@@ -33,6 +33,9 @@ func (k KncServer) kncRequest(data []byte) ([]byte, error) {
 
 	response, err := cmd.Output()
 	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			err = fmt.Errorf("%s\n--- knc stderr start ---\n%s\n--- knc stderr end ---\n", ee.Error(), string(ee.Stderr))
+		}
 		return nil, err
 	}
 
@@ -48,6 +51,10 @@ func (k KncServer) SendRequests(reqs []reqtarget.Request) ([]string, error) {
 	raw_resps, err := k.kncRequest(raw_reqs)
 	if err != nil {
 		return nil, fmt.Errorf("while performing request: %s", err)
+	}
+
+	if len(raw_resps) == 0 {
+		return nil, fmt.Errorf("empty response, likely because the server does not recognize your Kerberos identity")
 	}
 
 	resps := []string{}


### PR DESCRIPTION
Alleviates #179. Currently does rather fragile error message parsing for the hint message, but I think it's fine since, if the messages change, the hints simply won't be displayed.

The alternative is to do the diagnosis within keyreq itself, but it feels like this might not be keyreq's responsibility.