### PR TITLE
Fix #120: remove resource limits on the sidecar container

### DIFF
--- a/building/build-debs/homeworld-admin-tools/resources/clustered/dns-addon.yaml
+++ b/building/build-debs/homeworld-admin-tools/resources/clustered/dns-addon.yaml
@@ -133,10 +133,6 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
-        resources:
-          requests:
-            memory: 20Mi
-            cpu: 10m
         args:
         - /usr/bin/sidecar
         - --v=2


### PR DESCRIPTION
Due to a low CPU limit, the sidecar container would consistently fail to start
up before at least a few minutes had passed, at which point the entire pod
would fail and get restarted due to failing liveness tests.

This is not the correct long-term solution, since there should be limits, but
it solves the immediate problem, and we'll need to generate/regenerate limits
later anyway.

Ready for review, ~but not quite yet ready for merge, as I need to confirm that other observed restarts that occurred were caused by the infrastructure glitches we've been seeing, and not this particular issue~ and ready for merge.