### PR TITLE
Dns bootstrap during iso install

### DIFF
--- a/building/build-debs/homeworld-admin-tools/debian/changelog
+++ b/building/build-debs/homeworld-admin-tools/debian/changelog
@@ -1,3 +1,9 @@
+homeworld-admin-tools (0.1.50) stretch; urgency=medium
+
+  * Updated debian release
+
+ -- Matthew Ince <3cnfsat@gmail.com>  Mon, 29 Jan 2018 17:25:01 -0500
+
 homeworld-admin-tools (0.1.49) stretch; urgency=medium
 
   * Updated debian release

--- a/building/build-debs/homeworld-admin-tools/resources/postinstall.sh
+++ b/building/build-debs/homeworld-admin-tools/resources/postinstall.sh
@@ -39,6 +39,7 @@ cp /keyservertls.pem /target/etc/homeworld/keyclient/keyservertls.pem
 cp /keyclient-*.yaml /target/etc/homeworld/config/
 cp /keyclient-base.yaml /target/etc/homeworld/config/keyclient.yaml
 cp /sshd_config.new /target/etc/ssh/sshd_config
+cat /dns_bootstrap_lines >> /target/etc/hosts
 
 cat >/tmp/token.template <<EOF
 Template: homeworld/asktoken

--- a/building/build-debs/homeworld-admin-tools/src/iso.py
+++ b/building/build-debs/homeworld-admin-tools/src/iso.py
@@ -10,6 +10,7 @@ import subprocess
 import util
 import packages
 import keycrypt
+import setup
 from version import get_git_version
 
 PACKAGES = ("homeworld-apt-setup",)
@@ -54,6 +55,10 @@ def gen_iso(iso_image, authorized_key, cdpack=None):
     with tempfile.TemporaryDirectory() as d:
         inclusion = []
 
+        with open(os.path.join(d, "dns_bootstrap_lines"), "w") as outfile:
+            outfile.writelines(setup.dns_bootstrap_lines());
+
+        inclusion += ["dns_bootstrap_lines"]
         util.copy(authorized_key, os.path.join(d, "authorized.pub"))
         util.writefile(os.path.join(d, "keyservertls.pem"), authority.get_pubkey_by_filename("./server.pem"))
         resource.copy_to("postinstall.sh", os.path.join(d, "postinstall.sh"))

--- a/building/build-debs/homeworld-admin-tools/src/seq.py
+++ b/building/build-debs/homeworld-admin-tools/src/seq.py
@@ -60,8 +60,6 @@ def sequence_cluster(ops: setup.Operations) -> None:
     ops.add_operation("verify that the fundamental cluster infrastructure is online",
                       iterative_verifier(verify.check_online, 120.0))
 
-    ops.add_subcommand(setup.setup_dns_bootstrap)
-
     ops.add_operation("verify that etcd has launched successfully",
                       iterative_verifier(verify.check_etcd_health, 120.0))
     ops.add_operation("verify that kubernetes has launched successfully",

--- a/building/build-debs/homeworld-admin-tools/src/setup.py
+++ b/building/build-debs/homeworld-admin-tools/src/setup.py
@@ -191,6 +191,11 @@ def modify_dns_bootstrap(ops: Operations, is_install: bool) -> None:
                 ops.ssh_raw("bootstrap dns on @HOST: %s" % hostname, node, strip_cmd)
 
 
+def dns_bootstrap_lines() -> list:
+    config = configuration.get_config()
+    return ["%s\t%s # AUTO-HOMEWORLD-BOOTSTRAP" % (ip, hostname) for hostname, ip in config.dns_bootstrap.items()]
+
+
 def setup_dns_bootstrap(ops: Operations) -> None:
     modify_dns_bootstrap(ops, True)
 


### PR DESCRIPTION
Tested changes by bouncing the cluster with the "normal" DNS bootstrap code `` ops.add_subcommand(setup.setup_dns_bootstrap)`` commented out in seq.py.
