### PR TITLE
Allow us to configure glass to upload via rsync

### DIFF
--- a/building/apt-branch-config/branches.yaml.example
+++ b/building/apt-branch-config/branches.yaml.example
@@ -1,6 +1,11 @@
 branches:
   - name: root/master
     signing-key: d167aca2e5fcf374
-  - name: <name>/<subbranch>
+  - name: <host>/<location>/<of>/<repository>
     signing-key: <signing key>
-    apt-url-prefix: homeworld.deploy
+    upload:
+      method: rsync
+	  # these will be passed to rsync as
+	  # <username>@<host>:<dir>/<location>/<of>/<repository>
+	  user: <username>
+      dir: /var/www/html

--- a/building/apt-branch-config/branches.yaml.example
+++ b/building/apt-branch-config/branches.yaml.example
@@ -1,11 +1,14 @@
+upload-targets:
+  - name: <upload target>
+    method: rsync
+    # these will be passed to rsync as
+	# <username>@<host>:<dir>/<location>/<of>/<repository>
+	user: <username>
+    dir: /var/www/html
+
 branches:
   - name: root/master
     signing-key: d167aca2e5fcf374
   - name: <host>/<location>/<of>/<repository>
     signing-key: <signing key>
-    upload:
-      method: rsync
-	  # these will be passed to rsync as
-	  # <username>@<host>:<dir>/<location>/<of>/<repository>
-	  user: <username>
-      dir: /var/www/html
+    upload-target: <upload target>

--- a/building/components/homeworld-apt-setup/glass.yaml
+++ b/building/components/homeworld-apt-setup/glass.yaml
@@ -12,7 +12,7 @@ build:
   - type: python
     input: homeworld.sources.in
     output: /etc/apt/sources.list.d/homeworld.sources
-    code: return input.format(APT_URL=context.branch_config.apt_url)
+    code: return input.format(APT_URL=context.branch)
 
   - type: python
     input: homeworld.pref.in

--- a/building/components/homeworld-bootstrap-registry/glass.yaml
+++ b/building/components/homeworld-bootstrap-registry/glass.yaml
@@ -17,7 +17,7 @@ build:
   - type: python
     input: index.html.in
     output: /usr/lib/hyades/registry/index.html
-    code: return input.format(APT_URL=context.branch_config.apt_url)
+    code: return input.format(APT_URL=context.branch)
 
   - type: python
     output: /usr/lib/hyades/registry/pubkey.asc

--- a/building/glass/aptbranch.py
+++ b/building/glass/aptbranch.py
@@ -6,6 +6,9 @@ import subprocess
 
 import validate
 
+
+APT_BRANCH_REGEX = "^[0-9a-zA-Z_.-][0-9a-zA-Z_./-]+[0-9a-zA-Z_.-]$"
+
 CONFIG_PATH = "/h/apt-branch-config/branches.yaml"
 CONFIG_SCHEMA_NAME = "branches-schema.yaml"
 
@@ -18,9 +21,10 @@ def get_env_branch():
     if not branch:
         return None
 
-    if not re.match("^[0-9a-zA-Z_.-]+/[0-9a-zA-Z_.-]+$", branch):
-        print("apt branch should be of the form <username>/<branch>")
-        print("allowed characters: [0-9a-zA-Z_.-]")
+    if not re.match(APT_BRANCH_REGEX, branch):
+        print("apt branch should be a url path")
+        print("e.g. homeworld.apt/branch/subbranch")
+        print("allowed characters: [0-9a-zA-Z_./-]")
         raise Exception("invalid apt branch: %s" % branch)
 
     return branch
@@ -67,10 +71,9 @@ class Config:
     @property
     def signing_key(self) -> str:
         return self.config["signing-key"]
-
+    
     @property
-    def apt_url(self):
-        url_prefix = self.config.get("apt-url-prefix", "")
-        if url_prefix and not url_prefix.endswith("/"):
-            url_prefix += "/"
-        return url_prefix + self.name
+    def upload_config(self):
+        if "upload" not in self.config:
+            raise Exception("no upload config found in branch %s" % self.name)
+        return self.config["upload"]

--- a/building/glass/branches-schema.yaml
+++ b/building/glass/branches-schema.yaml
@@ -9,12 +9,27 @@ properties:
       properties:
         name:
           type: string
-          pattern: "^[0-9a-zA-Z_.-]+/[0-9a-zA-Z_.-]+$"
+          pattern: "^[0-9a-zA-Z_.-][0-9a-zA-Z_./-]+[0-9a-zA-Z_.-]$"
         signing-key:
           type: string
           pattern: "^[a-fA-F0-9]+$"
-        apt-url-prefix:
-          type: string
+        upload:
+          type: object
+          oneOf:
+          - properties:
+              method:
+                enum: ["google-cloud-storage"]
+            required: ["method"]
+            additionalProperties: false
+          - properties:
+              method:
+                enum: ["rsync"]
+              user:
+                type: string
+              dir:
+                type: string
+            required: ["method", "user", "dir"]
+            additionalProperties: false
       required: ["name", "signing-key"]
       additionalProperties: false
 required: ["branches"]

--- a/building/glass/branches-schema.yaml
+++ b/building/glass/branches-schema.yaml
@@ -2,6 +2,29 @@ $schema: "http://json-schema.org/draft-07/schema#"
 title: BranchesConfig
 type: object
 properties:
+  upload-targets:
+    type: array
+    items:
+      type: object
+      oneOf:
+        - properties:
+            name:
+              type: string
+            method:
+              enum: ["google-cloud-storage"]
+          required: ["name", "method"]
+          additionalProperties: false
+        - properties:
+            name:
+              type: string
+            method:
+              enum: ["rsync"]
+            user:
+              type: string
+            dir:
+              type: string
+          required: ["name", "method", "user", "dir"]
+          additionalProperties: false
   branches:
     type: array
     items:
@@ -13,23 +36,8 @@ properties:
         signing-key:
           type: string
           pattern: "^[a-fA-F0-9]+$"
-        upload:
-          type: object
-          oneOf:
-          - properties:
-              method:
-                enum: ["google-cloud-storage"]
-            required: ["method"]
-            additionalProperties: false
-          - properties:
-              method:
-                enum: ["rsync"]
-              user:
-                type: string
-              dir:
-                type: string
-            required: ["method", "user", "dir"]
-            additionalProperties: false
+        upload-target:
+          type: string
       required: ["name", "signing-key"]
       additionalProperties: false
 required: ["branches"]

--- a/building/glass/upload.py
+++ b/building/glass/upload.py
@@ -11,6 +11,7 @@ import project
 # given a repository descriptor of:
 #   HOMEWORLD_APT_BRANCH=hyades-deploy.celskeggs.com/test01
 # the following would be populated into hyades-deploy.celskeggs.com
+# (or, for rsync, <host>:<dir>/hyades-deploy.celskeggs.com/)
 #
 # /test01/
 # /test01/dists/
@@ -23,16 +24,8 @@ import project
 # /test01/aci/homeworld.private/flannel-0.8.0-4-linux-amd64.aci.asc
 
 
-# NOTE: currently assumes that google cloud storage is in use.
-# This is a bad assumption and should be changed.
-
-branch_regex = re.compile("[a-z0-9-]+[.][a-z0-9.-]+/[a-z0-9-]+")
-
-
 def upload(bindir: str, branch_config: aptbranch.Config) -> None:
     branch = branch_config.name
-    if not branch_regex.match(branch):
-        raise Exception("not an uploadable branch: %s" % branch)
     keyid = branch_config.signing_key
 
     files = os.listdir(bindir)
@@ -56,7 +49,7 @@ def upload(bindir: str, branch_config: aptbranch.Config) -> None:
         upload_apt(debs, uploads, keyid, tempdir)
 
         project.log("upload", "performing", len(uploads), "uploads to", branch)
-        perform_uploads(uploads, branch)
+        perform_uploads(uploads, branch_config)
         project.log("upload", "upload to", branch, "complete!")
 
 
@@ -108,6 +101,9 @@ def gs_rsync(local_path: str, remote_path: str, boto_path: str):
     subprocess.check_call(["gsutil", "-h", "Cache-Control:private, max-age=0, no-transform", "-m", "rsync", "-d", "-r", "-c", local_path, "gs://" + remote_path], env=env)
 
 
+GS_BRANCH_REGEX = re.compile("[a-z0-9-]+[.][a-z0-9.-]+/[a-z0-9-]+")
+
+
 BOTO_PATH = "/homeworld/boto-key"
 
 
@@ -123,9 +119,38 @@ default_project_id = %s
 """.lstrip()
 
 
-def perform_uploads(uploads: dict, branch: str) -> None:
+def upload_gs(staging, root: str, branch_config: aptbranch.Config):
+    branch = branch_config.name
+    if not GS_BRANCH_REGEX.match(branch):
+        raise Exception("not an uploadable branch: %s" % branch)
     if not os.path.exists(BOTO_PATH):
         raise Exception("you need to put the GCP service account private key file into /homeworld/boto-key")
+    botoconfig_name = os.path.join(staging, "boto.config")
+    with open(botoconfig_name, "w") as bout:
+        with open(BOTO_PATH, "r") as f:
+            project_id = json.load(f)["project_id"]
+        bout.write(BOTO_TEMPLATE % (BOTO_PATH, project_id))
+        bout.flush()
+    gs_rsync(root, branch, botoconfig_name)
+
+
+def upload_rsync(staging, root: str, branch_config: aptbranch.Config):
+    host, path = branch_config.name.split('/', 1)
+    target_dir = os.path.join(branch_config.upload_config["dir"], path)
+    user = branch_config.upload_config["user"]
+    if "@" in user or ":" in user:
+        raise Exception("unsupported characters (@ or :) in upload user")
+    dest = "%s@%s:%s" % (user, host, target_dir)
+    subprocess.check_call(["rsync", "-avzc", "--progress", "--delete-delay", "--", root + "/", dest])
+
+
+UPLOAD_FUNCS = {
+    "google-cloud-storage": upload_gs,
+    "rsync": upload_rsync
+}
+
+
+def perform_uploads(uploads: dict, branch_config: aptbranch.Config) -> None:
     with tempfile.TemporaryDirectory() as staging:
         root = os.path.join(staging, "root")
         for remote_path, local_path in uploads.items():
@@ -133,10 +158,8 @@ def perform_uploads(uploads: dict, branch: str) -> None:
             if not os.path.isdir(os.path.dirname(target)):
                 os.makedirs(os.path.dirname(target))
             shutil.copy2(local_path, target)
-        botoconfig_name = os.path.join(staging, "boto.config")
-        with open(botoconfig_name, "w") as bout:
-            with open(BOTO_PATH, "r") as f:
-                project_id = json.load(f)["project_id"]
-            bout.write(BOTO_TEMPLATE % (BOTO_PATH, project_id))
-            bout.flush()
-        gs_rsync(root, branch, botoconfig_name)
+
+        upload_method = branch_config.upload_config["method"]
+        if upload_method not in UPLOAD_FUNCS:
+            raise Exception("unrecognized upload method %s" % upload_method)
+        UPLOAD_FUNCS[upload_method](staging, root, branch_config)

--- a/chroot-packages.list
+++ b/chroot-packages.list
@@ -32,7 +32,7 @@ bzip2, ca-certificates, curl, gzip, less, sudo
 python3-jsonschema, reprepro, python3-apt
 
 # uploading
-python-pip, python-setuptools
+python-pip, python-setuptools, ssh
 
 # killall
 psmisc

--- a/enter-chroot.sh
+++ b/enter-chroot.sh
@@ -24,4 +24,9 @@ then
 	cp "$HOME/.gnupg/trustdb.gpg" "$HOMEWORLD_CHROOT/home/$USER/.gnupg/trustdb.gpg"
 	cp -R "$HOME/.gnupg/private-keys-v1.d/"* "$HOMEWORLD_CHROOT/home/$USER/.gnupg/private-keys-v1.d"
 fi
+if [ -e "$HOME/.ssh" ]
+then
+	mkdir -p "$HOMEWORLD_CHROOT/home/$USER/.ssh/"
+	cp -R "$HOME/.ssh/." "$HOMEWORLD_CHROOT/home/$USER/.ssh"
+fi
 sudo systemd-nspawn -M "$(basename $HOMEWORLD_CHROOT)" --bind $(pwd):/homeworld:norbind -u "$USER" -a -D "$HOMEWORLD_CHROOT" bash -c "cd /h/${ORIG_REL} && gpg-agent --daemon --keep-tty && sudo nginx && exec bash"


### PR DESCRIPTION
~First step towards local deploy. I haven't tested this through a full deploy yet, but I wanted to get some feedback on my approach. It currently works up to installing homeworld-admin-tools on the deployment VM.~

This adds rsync as an alternative option for upload, so that developers can deploy without GCS. Since rsync requires a somewhat larger amount of configuration that would be the same across multiple apt branches on the same upload target, this is implemented so that the same upload target configuration can be reused across branches easily.

This is tested via #321 since it was necessary for deployment to work with my own repository signing key.

There isn't an issue assigned for this.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.