### PR TITLE
 cluster: bump container versions

### DIFF
--- a/building/components/homeworld-admin-tools/resources/clustered/dns-addon.yaml
+++ b/building/components/homeworld-admin-tools/resources/clustered/dns-addon.yaml
@@ -87,7 +87,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: homeworld.mit.edu/dnsmasq-nanny:1.14.8-3
+        image: homeworld.mit.edu/dnsmasq-nanny:1.14.8-4
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq

--- a/building/components/homeworld-admin-tools/resources/clustered/flannel.yaml
+++ b/building/components/homeworld-admin-tools/resources/clustered/flannel.yaml
@@ -45,7 +45,7 @@ spec:
       serviceAccountName: flannel
       containers:
       - name: kube-flannel
-        image: homeworld.mit.edu/flannel:0.10.0-3
+        image: homeworld.mit.edu/flannel:0.10.0-4
         command: [ "/usr/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
         securityContext:
           privileged: true


### PR DESCRIPTION
    cluster: bump container versions
    
    Bump the versions of dnsmasq-nanny and flannel in the kubernetes
    configuration files.
    
    The previous commit bf84c1f4ba68f97c93e96dc002d0d7b79fcbb929 updated
    the versions of the dnsmasq-nanny and flannel containers as a result of
    updating their debian versions, but failed to also update the versions
    used for cluster deploy itself.

This is one of those times when I regret not testing previous changes more thoroughly.

~(This also contains a commit from the previously-approved PR #296, because I'm still waiting on that PR's tests passing before merge; please ignore that.)~