### PR TITLE
spire: eliminate cdpack system, split out ISO into separate package

### DIFF
--- a/building/components/homeworld-admin-tools/glass.yaml
+++ b/building/components/homeworld-admin-tools/glass.yaml
@@ -1,6 +1,6 @@
 control:
   name: homeworld-admin-tools
-  version: 0.2.3
+  version: 0.2.4
   date: 2018-07-10T17:16:23-0700
   type: deb
   depends:

--- a/building/components/homeworld-admin-tools/glass.yaml
+++ b/building/components/homeworld-admin-tools/glass.yaml
@@ -1,7 +1,7 @@
 control:
   name: homeworld-admin-tools
-  version: 0.2.1
-  date: 2018-07-10T15:28:30-0700
+  version: 0.2.2
+  date: 2018-07-10T17:16:23-0700
   type: deb
   depends:
     - homeworld-keysystem
@@ -55,8 +55,6 @@ build:
   # todo: add a 'pypack' target or something
   - type: bash
     code: |
-      (cd src && zip --quiet -r ${STAGE}/spire-temp.zip *)
-      python3 spire-temp.zip iso regen-cdpack debian.iso src/resources/debian-cdpack.tgz
       (cd src && zip --quiet -r ${STAGE}/spire.zip *)
       echo "#!/usr/bin/env python3" | cat - spire.zip >spire
       chmod +x spire
@@ -64,3 +62,7 @@ build:
   - type: copy
     stage: spire
     output: /usr/bin/spire
+
+  - type: copy
+    stage: debian.iso
+    output: /usr/share/spire/debian.iso

--- a/building/components/homeworld-admin-tools/glass.yaml
+++ b/building/components/homeworld-admin-tools/glass.yaml
@@ -1,12 +1,13 @@
 control:
   name: homeworld-admin-tools
-  version: 0.2.2
+  version: 0.2.3
   date: 2018-07-10T17:16:23-0700
   type: deb
   depends:
     - homeworld-keysystem
     - homeworld-hyperkube
     - homeworld-etcd
+    - homeworld-debian-iso
     - libarchive-tools
     - python3
     - python3-yaml
@@ -47,11 +48,6 @@ build:
     stage: src/resources/DEB_VERSION
     code: return project.full_version
 
-  - type: upstream
-    upstream: debian-%-amd64-mini.iso
-    version: 9.5.0
-    stage: debian.iso
-
   # todo: add a 'pypack' target or something
   - type: bash
     code: |
@@ -62,7 +58,3 @@ build:
   - type: copy
     stage: spire
     output: /usr/bin/spire
-
-  - type: copy
-    stage: debian.iso
-    output: /usr/share/spire/debian.iso

--- a/building/components/homeworld-admin-tools/src/iso.py
+++ b/building/components/homeworld-admin-tools/src/iso.py
@@ -81,7 +81,7 @@ def gen_iso(iso_image, authorized_key):
 
         cddir = os.path.join(d, "cd")
         os.mkdir(cddir)
-        subprocess.check_call(["bsdtar", "-C", cddir, "-xzf", "/usr/share/spire/debian.iso"])
+        subprocess.check_call(["bsdtar", "-C", cddir, "-xzf", "/usr/share/homeworld/debian.iso"])
         subprocess.check_call(["chmod", "+w", "--recursive", cddir])
 
         subprocess.check_call(["gunzip", os.path.join(cddir, "initrd.gz")])

--- a/building/components/homeworld-debian-iso/glass.yaml
+++ b/building/components/homeworld-debian-iso/glass.yaml
@@ -1,0 +1,15 @@
+control:
+  name: homeworld-debian-iso
+  version: 9.5.0-1
+  date: 2018-07-10T20:12:24-0700
+  type: deb
+
+build:
+  - type: upstream
+    upstream: debian-%-amd64-mini.iso
+    version: 9.5.0
+    stage: debian.iso
+
+  - type: copy
+    stage: debian.iso
+    output: /usr/share/homeworld/debian.iso


### PR DESCRIPTION
Remove the separate step of extracting the debian ISO during build, and
eliminate the effort of rebuilding and reuploading a copy of the debian
ISO every time that spire is modified.

The spire cdpack system was implemented when we didn't have bsdtar, and
correspondingly needed to perform an actual mount operation to read the
files out of the debian base ISO. We no longer need to do this, so the
cdpack process can be re-integrated back into the main ISO remastering
process.

We also relocate the debian ISO to /usr/share/homeworld/debian.iso, because
it doesn't make much sense to incorporate this kind of binary into the
deployed spire binary, when we could also put it in the debian package -- or
even a different package.