### PR TITLE
Enforce long fingerprints in branches.yaml

### DIFF
--- a/building/apt-branch-config/branches-ci.yaml
+++ b/building/apt-branch-config/branches-ci.yaml
@@ -1,3 +1,3 @@
 branches:
   - name: root/master
-    signing-key: d167aca2e5fcf374
+    signing-key: A1EBB6EA29A86C445A187CB9D167ACA2E5FCF374

--- a/building/glass/branches-schema.yaml
+++ b/building/glass/branches-schema.yaml
@@ -35,7 +35,7 @@ properties:
           pattern: "^[0-9a-zA-Z_.-][0-9a-zA-Z_./-]+[0-9a-zA-Z_.-]$"
         signing-key:
           type: string
-          pattern: "^[a-fA-F0-9]+$"
+          pattern: "^[a-fA-F0-9]{40}$"
         upload-target:
           type: string
       required: ["name", "signing-key"]


### PR DESCRIPTION
This commit opts to enforce full length fingerprints in branches.yaml directly during validation, since it is generally good practice to use full-length fingerprints in configuration files anyway.

See #327.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
