### PR TITLE
spire: generate usb-bootable ISOs

### DIFF
--- a/building/components/homeworld-admin-tools/glass.yaml
+++ b/building/components/homeworld-admin-tools/glass.yaml
@@ -1,7 +1,7 @@
 control:
   name: homeworld-admin-tools
-  version: 0.2.31
-  date: 2018-07-31T23:12:30-0700
+  version: 0.2.32
+  date: 2018-09-29T15:12:12-0400
   type: deb
   depends:
     - homeworld-keysystem
@@ -13,7 +13,8 @@ control:
     - python3-yaml
     - python3-requests
     - pwgen
-    - genisoimage
+    - xorriso
+    - syslinux-utils
     - whois
     - cpio
 

--- a/building/components/homeworld-admin-tools/src/iso.py
+++ b/building/components/homeworld-admin-tools/src/iso.py
@@ -129,7 +129,10 @@ def gen_iso(iso_image, authorized_key, mode=None):
         md5s = subprocess.check_output(["md5sum", "--"] + files_for_md5sum, cwd=cddir)
         util.writefile(os.path.join(cddir, "md5sum.txt"), md5s)
 
-        subprocess.check_call(["genisoimage", "-quiet", "-o", iso_image, "-r", "-J", "-no-emul-boot", "-boot-load-size", "4", "-boot-info-table", "-b", "isolinux.bin", "-c", "isolinux.cat", cddir])
+        temp_iso = os.path.join(d, "temp.iso")
+        subprocess.check_call(["xorriso", "-as", "mkisofs", "-quiet", "-o", temp_iso, "-r", "-J", "-c", "boot.cat", "-b", "isolinux.bin", "-no-emul-boot", "-boot-load-size", "4", "-boot-info-table", cddir])
+        subprocess.check_call(["isohybrid", "-h", "64", "-s", "32", temp_iso])
+        util.copy(temp_iso, iso_image)
 
 
 main_command = command.mux_map("commands about building installation ISOs", {


### PR DESCRIPTION
The ISOs generated directly by genisoimage failed to boot on real
hardware, when installation was attempted via a USB boot drive. Fix
this by using xorriso + isohybrid, which generate an ISO that is also
bootable when written to a USB drive.

Fixes #332.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] ~I have formatted any Go code that I have changed with gofmt.~
 - [x] I have signed each commit with my GPG key.
 - [ ] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [ ] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [ ] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
