### PR TITLE
deploy chroot scripts

### DIFF
--- a/create-chroot.sh
+++ b/create-chroot.sh
@@ -46,8 +46,6 @@ EOF
 sudo bash -c "cat >>${HOMEWORLD_CHROOT}/home/$USER/.bashrc" <<EOF
 export PS1="\[\033[01;31m\][homeworld] \[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ "
 EOF
-sudo mkdir "${HOMEWORLD_CHROOT}/fstemp/"
-sudo chown "$USER" "${HOMEWORLD_CHROOT}/fstemp/"
 echo "127.0.0.1 $(basename "$HOMEWORLD_CHROOT")" | sudo bash -c "cat >>'$HOMEWORLD_CHROOT/etc/hosts'"
 
 echo "Done!"

--- a/deploy-chroot/create.sh
+++ b/deploy-chroot/create.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e -u
+
+cd "$(dirname "$0")"
+
+if [ "${HOMEWORLD_DEPLOY_CHROOT:-}" = "" -o ! -e "$(dirname HOMEWORLD_DEPLOY_CHROOT)" ]
+then
+    echo "invalid path to chroot: ${HOMEWORLD_DEPLOY_CHROOT:-}" 1>&2
+    echo '(have you populated $HOMEWORLD_DEPLOY_CHROOT?)'
+    echo '(try export HOMEWORLD_DEPLOY_CHROOT=$HOME/chroot)'
+    exit 1
+fi
+
+if [[ "${HOMEWORLD_DEPLOY_CHROOT}" =~ " " ]]
+then
+    echo "chroot name cannot include a space" 1>&2
+    exit 1
+fi
+
+if [ -e "${HOMEWORLD_DEPLOY_CHROOT}" ]
+then
+    echo "chroot already exists" 1>&2
+    exit 1
+fi
+
+if [ "$USER" = "root" ]
+then
+    echo "this script should be run as a user with sudo capabilities" 1>&2
+    exit 1
+fi
+
+mkdir -m 'u=rwx,go=rx' "${HOMEWORLD_DEPLOY_CHROOT}"
+
+sudo debootstrap --include="$(cat packages.list | grep -vE '^#' | tr '\n ' ',,' | sed 's/,$//' | sed 's/,,/,/g')" stretch "${HOMEWORLD_DEPLOY_CHROOT}" http://debian.csail.mit.edu/debian/
+sudo chroot "${HOMEWORLD_DEPLOY_CHROOT}" apt-get update
+sudo chroot "${HOMEWORLD_DEPLOY_CHROOT}" groupadd "$(id -gn)" -g "$(id -g)"
+sudo chroot "${HOMEWORLD_DEPLOY_CHROOT}" useradd -m -u "$(id -u)" -g "$(id -g)" -G kvm "$USER" -s "/bin/bash"
+sudo bash -c "echo '$USER ALL=(ALL) NOPASSWD:ALL' >>'${HOMEWORLD_DEPLOY_CHROOT}/etc/sudoers'"
+sudo bash -c "cat >>${HOMEWORLD_DEPLOY_CHROOT}/etc/bash.bashrc" <<EOF
+export PS1="\[\033[01;31m\][hyades deploy] \[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ "
+EOF
+cat >>"${HOMEWORLD_DEPLOY_CHROOT}/home/$USER/.bashrc" <<EOF
+export PS1="\[\033[01;31m\][hyades deploy] \[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\]\$ "
+EOF
+mkdir -m 'u=rwx,go=' "${HOMEWORLD_DEPLOY_CHROOT}/home/$USER/.ssh"
+ssh-keygen -t rsa -N "" -f "${HOMEWORLD_DEPLOY_CHROOT}/home/$USER/.ssh/id_rsa"
+echo "127.0.0.1 $(basename "$HOMEWORLD_DEPLOY_CHROOT")" | sudo bash -c "cat >>'$HOMEWORLD_DEPLOY_CHROOT/etc/hosts'"
+
+echo "Done!"

--- a/deploy-chroot/enter.sh
+++ b/deploy-chroot/enter.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e -u
+
+if [ "${HOMEWORLD_DEPLOY_CHROOT:-}" = "" -o ! -e "${HOMEWORLD_DEPLOY_CHROOT}" ]
+then
+    echo "invalid path to chroot: ${HOMEWORLD_DEPLOY_CHROOT:-}" 1>&2
+    echo '(have you populated $HOMEWORLD_DEPLOY_CHROOT?)'
+    echo '(have you created a chroot?)'
+    exit 1
+fi
+
+cd "$(dirname "$0")"
+cd "$(git rev-parse --show-toplevel)"
+sudo systemd-nspawn -E PATH="/usr/local/bin:/usr/bin:/bin" -E HOMEWORLD_DIR="/cluster" -E HOMEWORLD_DISASTER="/disaster" -M "$(basename $HOMEWORLD_DEPLOY_CHROOT)" --bind $(pwd):/homeworld:norbind --bind "$HOMEWORLD_DIR":/cluster:norbind --bind "$HOMEWORLD_DISASTER":/disaster:norbind -u "$USER" -a -D "$HOMEWORLD_DEPLOY_CHROOT" --capability=CAP_NET_ADMIN --bind /dev/kvm:/dev/kvm:norbind bash -c "sudo mount -o rw,remount /proc/sys && sudo chgrp kvm /dev/kvm && cd /cluster && exec ssh-agent bash"

--- a/deploy-chroot/generate-setup.py
+++ b/deploy-chroot/generate-setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import argparse
+import os.path
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser()
+    p.add_argument('subnet_byte', help='A unique-per-host byte for which private network to use.')
+    args = p.parse_args()
+
+    if not (0 <= int(args.subnet_byte) < 256):
+        raise ValueError('subnet_byte must be a byte')
+
+    with open(os.path.expandvars('$HOMEWORLD_DIR/setup.yaml.in')) as fin, open(os.path.expandvars('$HOMEWORLD_DIR/setup.yaml'), 'w') as fout:
+        fout.write(fin.read().format(x=args.subnet_byte))

--- a/deploy-chroot/packages.list
+++ b/deploy-chroot/packages.list
@@ -1,0 +1,14 @@
+# sudo
+sudo
+
+# brctl
+bridge-utils
+
+# qemu
+qemu-system-x86 qemu-utils
+
+# kvm
+linux-image-amd64
+
+# ssh
+ssh

--- a/deploy-chroot/reinstall-spire.sh
+++ b/deploy-chroot/reinstall-spire.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e -u
+
+if [ "${HOMEWORLD_DEPLOY_CHROOT:-}" = "" -o ! -e "${HOMEWORLD_DEPLOY_CHROOT}" ]
+then
+    echo "invalid path to chroot: ${HOMEWORLD_DEPLOY_CHROOT:-}" 1>&2
+    echo '(have you populated $HOMEWORLD_DEPLOY_CHROOT?)'
+    echo '(have you created a chroot?)'
+    exit 1
+fi
+
+cd "$(dirname "$0")"
+cd "$(git rev-parse --show-toplevel)"
+sudo systemd-nspawn -E PATH="/usr/local/bin:/usr/bin:/bin" -M "$(basename $HOMEWORLD_DEPLOY_CHROOT)" --bind $(pwd):/homeworld:norbind -u "$USER" -a -D "$HOMEWORLD_DEPLOY_CHROOT" bash -c "cd /homeworld && (sudo apt-get -y purge homeworld-apt-setup && sudo apt-get -y remove 'homeworld-*' && sudo apt-get clean || true) && sudo dpkg -i apt-setup.deb && sudo apt-get update && sudo apt-get -y install homeworld-spire"

--- a/deploy-chroot/setup.yaml.in
+++ b/deploy-chroot/setup.yaml.in
@@ -1,0 +1,42 @@
+cluster:
+  external-domain: pink.example.org
+  internal-domain: hyades.local
+  etcd-token: sample-1
+  kerberos-realm: ATHENA.MIT.EDU
+  mirror: debian.csail.mit.edu/debian
+  user-grant-domain: ''
+
+addresses:
+  cidr-nodes: 10.{x}.0.0/24
+  cidr-pods: 172.18.0.0/16
+  cidr-services: 172.28.0.0/16
+  service-api: 172.28.0.1
+  service-dns: 172.28.0.2
+
+dns-upstreams:
+  - 18.70.0.160
+  - 18.71.0.151
+  - 18.72.0.3
+
+dns-bootstrap:
+  homeworld.private: 10.{x}.0.2
+  jet.pink.example.org: 10.{x}.0.2
+  jade.pink.example.org: 10.{x}.0.3
+  jasper.pink.example.org: 10.{x}.0.4
+
+# WARNING: empty root admins means that Kerberos authentication is
+# disabled. Make sure this is not empty in production.
+root-admins: []
+
+nodes:
+  - hostname: jet
+    ip: 10.{x}.0.2
+    kind: supervisor
+
+  - hostname: jade
+    ip: 10.{x}.0.3
+    kind: master
+
+  - hostname: jasper
+    ip: 10.{x}.0.4
+    kind: worker

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,23 +9,27 @@ If you're (re)deploying the cluster for development, you will need:
  * Access to toastfs-dev (the machine which hosts the development cluster). You will need a Kerberos root instance as a prerequisite to this.
  * Any VNC viewer. These instructions are based on [TigerVNC](https://github.com/TigerVNC/tigervnc/releases) (``sudo apt-get install tigervnc``).
 
-# Installing packages
+# Installing spire
 
-Start by getting the apt-setup package directly:
+Start by getting the apt-setup package.  Inside your build chroot, run:
 
-    $ cd platform
-    $ bazel build //apt-setup:package.deb
+    [homeworld] $ platform/extract-apt-setup.sh
 
-It will display a path to a package.deb:
+This places `apt-setup.deb` in your host homeworld directory.
 
-    Target //apt-setup:package.deb up-to-date:
-      bazel-bin/apt-setup/package.deb
+## Using spire in a chroot
 
-Copy this package to a common directory outside of the chroot:
+    $ deploy-chroot/create.sh  # create a deploy chroot
+    $ deploy-chroot/reinstall-spire.sh  # install spire in the chroot
+    $ deploy-chroot/enter.sh   # enter the chroot
 
-    $ cp bazel-bin/apt-setup/package.deb ../apt-setup.deb
+You can now run `spire` inside the deploy chroot.
+Rerun `extract-apt-setup.sh` and `reinstall-spire.sh`
+whenever you make changes in spire that you want to test.
 
-Copy this file (now in the root directory of the host homeworld folder) to the installation VM.
+## Manually installing spire
+
+Copy `apt-setup.deb` to the installation VM.
 
 Now, in your deploy VM:
 
@@ -33,7 +37,7 @@ Now, in your deploy VM:
     $ sudo apt-get update
     $ sudo apt-get install homeworld-spire
 
-This will provide access to the 'spire' tool.
+This will provide access to the `spire` command.
 
 # Setting up a new cluster from scratch
 
@@ -126,6 +130,16 @@ To download existing configuration:
     $ git clone git@github.mit.edu:sipb/hyades-cluster $HOMEWORLD_DIR
 
 Make sure to verify that you have the correct commit hash, out of band.
+
+## Autodeploy configuration
+
+To get an autodeploy configuration:
+
+    $ cp deploy-chroot/setup.yaml.in $HOMEWORLD_DIR
+    $ deploy-chroot/generate-setup.py <x>
+
+Here `<x>` is a byte which must be unique per machine
+if you plan to do multiple concurrent autodeploys.
 
 # Configuring SSH
 

--- a/platform/extract-apt-setup.sh
+++ b/platform/extract-apt-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e -u
+
+cd "$(dirname "$0")"
+bazel build //apt-setup:package.deb
+cp "$(bazel info bazel-bin)"/apt-setup/package.deb "$(git rev-parse --show-toplevel)"/apt-setup.deb
+chmod 'u=rw,go=r' "$(git rev-parse --show-toplevel)"/apt-setup.deb


### PR DESCRIPTION
Add scripts for creating a deploy chroot.  This allows for multiple installations of spire on the same machine, and thus for running multiple autodeploys at once.

See #363.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [ ] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
