### PR TITLE
Persistent autodeploy

### DIFF
--- a/platform/spire/src/command.py
+++ b/platform/spire/src/command.py
@@ -34,7 +34,7 @@ def get_command_for_function(f):
 
 def mux_map(desc: str, mapping: dict):
     def configure(command: list, parser: argparse.ArgumentParser):
-        parser.set_defaults(parser=parser)
+        parser.set_defaults(argparse_parser=parser)
         subparsers = parser.add_subparsers()
 
         for component, (inner_desc, inner_configure) in mapping.items():
@@ -57,7 +57,7 @@ def wrap(desc: str, func, paramtx=None):
     minarg, maxarg = get_argcount(func)
 
     def invoke(args):
-        params = args.params
+        params = args.argparse_params
         if paramtx:
             prev = len(params)
             params, on_end = paramtx(args)
@@ -83,8 +83,8 @@ def wrap(desc: str, func, paramtx=None):
             on_end()
 
     def configure(command: list, parser: argparse.ArgumentParser):
-        parser.set_defaults(invoke=invoke, parser=parser)
-        parser.add_argument('params', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+        parser.set_defaults(argparse_invoke=invoke, argparse_parser=parser)
+        parser.add_argument('argparse_params', nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
         provide_command_for_function(func, command)
 
     return desc, configure
@@ -96,10 +96,10 @@ def main_invoke(command):
     configure_parser(["spire"], parser)
     try:
         args = parser.parse_args()
-        if "invoke" in args:
-            args.invoke(args)
+        if "argparse_invoke" in args:
+            args.argparse_invoke(args)
         else:
-            args.parser.print_help()
+            args.argparse_parser.print_help()
         return 0
     except CommandFailedException as e:
         print(ANSI_ESCAPE_CODE_RED + 'command failed: ' + str(e) + ANSI_ESCAPE_CODE_RESET)

--- a/platform/spire/src/command.py
+++ b/platform/spire/src/command.py
@@ -75,7 +75,10 @@ def wrap(desc: str, func, paramtx=None):
             fail("not enough parameters (expected %s)" % expect)
         if maxarg is not None and len(params) > maxarg:
             fail("too many parameters (expected %s)" % expect)
-        func(*params)
+        varnames = func.__code__.co_varnames
+        opts = vars(args)
+        opts = { k: opts[k] for k in varnames if k in opts }
+        func(*params, **opts)
         if on_end:
             on_end()
 

--- a/platform/spire/src/seq.py
+++ b/platform/spire/src/seq.py
@@ -97,7 +97,7 @@ def wrapseq(desc: str, f):
             else:
                 ops.run_operations()
 
-        return [ops] + args.params, invoke
+        return [ops] + args.argparse_params, invoke
 
     desc, inner_configure = command.wrap(desc, f, wrap_param_tx)
 

--- a/platform/spire/src/setup.py
+++ b/platform/spire/src/setup.py
@@ -286,7 +286,7 @@ def setup_prometheus(ops: Operations) -> None:
 def wrapop(desc: str, f):
     def wrap_param_tx(args):
         ops = Operations()
-        return [ops] + args.params, ops.run_operations
+        return [ops] + args.argparse_params, ops.run_operations
     return command.wrap(desc, f, wrap_param_tx)
 
 


### PR DESCRIPTION
This adds a "--persistent" flag to the cluster autodeploy so that we can easily mess around with a correctly autodeployed cluster. Note that because of how argparse arguments are matched to optional function parameters, this means that no spire function should have "params", "invoke" or "parser" as optional parameters, and seq functions can't have "dry_run" or "dry_run_outer" (we can improve this by renaming those things to things we will never use).

(no issue assigned).

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
