### PR TITLE
debian: bump debian installer version

### DIFF
--- a/debian-checksum.sh
+++ b/debian-checksum.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e -u
+
+VERSION="20170615+deb9u6"
+
+WORK=$(mktemp -d)
+trap "rm -r $WORK" EXIT
+
+cd $WORK
+
+curl -sO 'http://debian.csail.mit.edu/debian/dists/stretch/Release'
+curl -sO 'http://debian.csail.mit.edu/debian/dists/stretch/Release.gpg'
+
+echo 'verifying Release against debian-archive-keyring' >&2
+gpg --no-default-keyring --keyring "/usr/share/keyrings/debian-archive-keyring.gpg" --quiet --verify Release.gpg Release 2>/dev/null >/dev/null || (echo [failed] >&2 && false)
+echo [success] >&2
+
+curl -sO "http://debian.csail.mit.edu/debian/dists/stretch/main/installer-amd64/$VERSION/images/SHA256SUMS"
+
+echo 'verifying SHA256SUMS against Release' >&2
+# [tail] because the sha256's are after the md5's :P
+echo $(grep "main/installer-amd64/$VERSION/images/SHA256SUMS" Release | tail -n 1 | cut -d " " -f 2) SHA256SUMS | sha256sum --check --strict >&2
+
+grep './netboot/mini.iso' SHA256SUMS | cut -d " " -f 1

--- a/platform/WORKSPACE
+++ b/platform/WORKSPACE
@@ -88,8 +88,8 @@ go_repository(
 
 http_file(
     name = "debian_iso",
-    urls = ["http://ftp.debian.org/debian/dists/stretch/main/installer-amd64/20170615+deb9u5+b2/images/netboot/mini.iso"],
-    sha256 = "256ff4122bb57d234068c21b3c78380d5960cd90922e44125ddfc2a2cb597e0a"
+    urls = ["http://ftp.debian.org/debian/dists/stretch/main/installer-amd64/20170615+deb9u6/images/netboot/mini.iso"],
+    sha256 = "53583c1bd3808aab8629faf16d57aad32ae791e77ec52b7c283f0f4efda69b24"
 )
 
 # dnsmasq


### PR DESCRIPTION
Bump the debian installer version from `20170615+deb9u5+b2` to `20170615+deb9u6`.  Also, add a script (based on an old Makefile from git history) for determining what the sha256sum of the debian installer iso should be.  This makes bumping the installer version easier in the future.

See #389.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
