### PR TITLE
rules_docker: upgrade for bazel compatibility

### DIFF
--- a/platform/WORKSPACE
+++ b/platform/WORKSPACE
@@ -28,11 +28,10 @@ load("//bazel:gorepo_patchfix.bzl", "go_repository_alt")
 
 gazelle_dependencies()
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_docker",
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+    remote = "https://github.com/bazelbuild/rules_docker",
+    commit = "968e0b7c8b3bc7e009531231ac926325cd2745bc",
 )
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")


### PR DESCRIPTION
Bazel removed some deprecated features, leading to a failure like the
following in rules_docker's subpar dependency:

  in default_python_version attribute of py_binary rule @subpar//compiler:compiler: the 'default_python_version' attribute is disabled by the '--incompatible_remove_old_python_version_api' flag

To fix this, we need to pull down a more recent (unreleased) version of
subpar, which can be pulled down by a more recent (also unreleased)
version of rules_docker. So switch to pull down the correct Git commit.

We should probably switch back to using http_archive once this change
is merged into a rules_docker release.

Fixes #395.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [ ] ~I have deployed a cluster incorporating my changes, and checked that it deploys successfully.~ (doesn't change much, so I'm just using the jenkins check for this)
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
