### PR TITLE
Add automatic launch command

### DIFF
--- a/.jenkins/jenkins-deploy.sh
+++ b/.jenkins/jenkins-deploy.sh
@@ -28,4 +28,4 @@ mkdir -p "$HOME/.ssh/"
 ssh-keygen -t rsa -N "" -f "$HOME/.ssh/id_rsa"
 eval "$(ssh-agent -s)"
 (cd /var/homeworld-deploy && (spire virt net down || true))
-(cd /var/homeworld-deploy && spire virt auto cluster)
+(cd /var/homeworld-deploy && spire virt auto install)

--- a/platform/spire/src/command.py
+++ b/platform/spire/src/command.py
@@ -87,6 +87,10 @@ def wrap(desc: str, func, param_tx=None):
             if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
                 if p.default == inspect.Parameter.empty:
                     parser.add_argument(p.name)
+                elif isinstance(p.default, bool):
+                    if p.default:
+                        raise Exception("arguments defaulting to True not supported")
+                    parser.add_argument("--%s" % (p.name), action="store_true")
                 else:
                     parser.add_argument(p.name, nargs='?', default=p.default)
             elif p.kind == inspect.Parameter.VAR_POSITIONAL:

--- a/platform/spire/src/command.py
+++ b/platform/spire/src/command.py
@@ -86,7 +86,7 @@ def wrap(desc: str, func, param_tx=None):
 
             if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
                 if p.default == inspect.Parameter.empty:
-                    parser.add_argument(p.name, nargs=1)
+                    parser.add_argument(p.name)
                 else:
                     parser.add_argument(p.name, nargs='?', default=p.default)
             elif p.kind == inspect.Parameter.VAR_POSITIONAL:

--- a/platform/spire/src/virt.py
+++ b/platform/spire/src/virt.py
@@ -521,22 +521,12 @@ def auto_cluster(ops: setup.Operations, authorized_key=None, persistent=False):
                 ops.add_subcommand(seq.sequence_cluster)
 
 
-def wrap_persistent(desc: str, f):
-    desc, inner_configure = seq.wrapseq(desc, f)
-
-    def configure(command: list, parser: argparse.ArgumentParser):
-        parser.add_argument("--persistent", dest="persistent", action="store_true", help="keep cluster running after it has been set up")
-        inner_configure(command, parser)
-
-    return desc, configure
-
-
 main_command = command.mux_map("commands to run local testing VMs", {
     "net": command.mux_map("commands to control the state of the local testing network", {
         "up": command.wrap("bring up local testing network", net_up),
         "down": command.wrap("bring down local testing network", net_down),
     }),
     "auto": seq.seq_mux_map("commands to perform large-scale operations automatically", {
-        "cluster": wrap_persistent("complete cluster installation", auto_cluster),
+        "cluster": seq.wrapseq("complete cluster installation", auto_cluster),
     }),
 })


### PR DESCRIPTION
This allows us to automatically launch the cluster without installing it first.

(no issue assigned)

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have signed each commit with my GPG key.
 - [x] My changes have passed CI.
 - [x] I have built my changes locally, and tested that the changes work as expected.
 - [x] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
