### PR TITLE
[wip] fix various bazel incompatibilities

### DIFF
--- a/platform/.bazelrc
+++ b/platform/.bazelrc
@@ -1,2 +1,3 @@
 startup --host_jvm_args=-Xmx4G
-build --workspace_status_command bazel/workspace-status.sh --host_force_python=PY2
+build --workspace_status_command bazel/workspace-status.sh
+build --incompatible_use_python_toolchains=false

--- a/platform/.bazelrc
+++ b/platform/.bazelrc
@@ -1,2 +1,2 @@
 startup --host_jvm_args=-Xmx4G
-build --workspace_status_command bazel/workspace-status.sh
+build --workspace_status_command bazel/workspace-status.sh --host_force_python=PY2

--- a/platform/WORKSPACE
+++ b/platform/WORKSPACE
@@ -1,42 +1,57 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+# rules_go
+
 # TODO: audit all downloads, make sure they're all source code
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz"
+        ],
+    sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
 )
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+# TODO: stop using binaries built by upstream; use our own
+go_register_toolchains(
+    go_version = "1.12.4",
+)
+load("//bazel:gorepo_patchfix.bzl", "go_repository_alt")
+
+# gazelle
 
 http_archive(
     name = "bazel_gazelle",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
     sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
 )
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
-
-go_rules_dependencies()
-
-# TODO: stop using binaries built by upstream; use our own
-go_register_toolchains(
-    go_version = "1.12.4",
-)
-
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-load("//bazel:gorepo_patchfix.bzl", "go_repository_alt")
-
 gazelle_dependencies()
+
+# protobuf
+
+git_repository(
+    name = "com_google_protobuf",
+    commit = "6a59a2ad1f61d9696092f79b6d74368b4d7970a3", # 3.9.0
+    remote = "https://github.com/protocolbuffers/protobuf",
+    shallow_since = "1558721209 -0700",
+)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
+
+# rules_docker
 
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker",
     commit = "968e0b7c8b3bc7e009531231ac926325cd2745bc",
 )
-
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
-
 container_repositories()
+
+# k8s repository infrastructure tools, k8s
 
 git_repository(
     name = "io_k8s_repo_infra",
@@ -82,6 +97,16 @@ go_repository(
     importpath = "github.com/kubernetes-sigs/cri-tools",
     build_file_proto_mode = "disable_global",
 )
+
+# debian packaging
+
+http_archive(
+    name = "rules_pkg",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
 
 # debian ISO
 
@@ -230,9 +255,21 @@ go_repository(
 )
 
 go_repository(
+    name = "org_golang_x_net",
+    commit = "da137c7871d730100384dbcf36e6f8fa493aef5b",
+    importpath = "golang.org/x/net",
+)
+
+go_repository(
     name = "org_golang_x_oauth2",
     commit = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4",
     importpath = "golang.org/x/oauth2",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    commit = "f21a4dfb5e38f5895301dc265a8def02365cc3d0", # 0.3.0
+    importpath = "golang.org/x/text",
 )
 
 go_repository(
@@ -260,6 +297,12 @@ go_repository(
 )
 
 # keysystem dependencies
+
+go_repository(
+    name = "org_golang_x_sys",
+    commit = "fae7ac547cb717d141c433a2a173315e216b64c4",
+    importpath = "golang.org/x/sys",
+)
 
 go_repository(
     name = "org_golang_x_crypto",

--- a/platform/WORKSPACE
+++ b/platform/WORKSPACE
@@ -102,8 +102,11 @@ go_repository(
 
 http_archive(
     name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
-    sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+    # TODO: update once the python 2/3 issues are worked out a bit
+    # url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    # sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.1.0/rules_pkg-0.1.0.tar.gz",
+    sha256 = "752146e2813f4c135ec9f71b592bf98f96f026049e6d65248534dbeccb2448e1",
 )
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()

--- a/platform/bazel/BUILD.bazel
+++ b/platform/bazel/BUILD.bazel
@@ -1,22 +1,22 @@
-native.py_binary(
+py_binary(
     name = "substitute",
     srcs = ["substitute.py"],
     visibility = ["//visibility:public"],
 )
 
-native.py_binary(
+py_binary(
     name = "version-compute",
     srcs = ["version-compute.py"],
     visibility = ["//visibility:public"],
 )
 
-native.py_binary(
+py_binary(
     name = "hash-compute",
     srcs = ["hash-compute.py"],
     visibility = ["//visibility:public"],
 )
 
-native.py_binary(
+py_binary(
     name = "cache-compute",
     srcs = ["cache-compute.py"],
     visibility = ["//visibility:public"],

--- a/platform/bazel/hash-compute.py
+++ b/platform/bazel/hash-compute.py
@@ -25,7 +25,7 @@ def sha256_file(f):
 hashes = [sha256(b"".join(sha256(arg) for arg in args))]
 for input in files:
     if input == "--empty":
-        hashes.append("(empty)")  # not a real hash, but we're going to hash it again, so it's okay
+        hashes.append(b"(empty)")  # not a real hash, but we're going to hash it again, so it's okay
     else:
         with open(input, "rb") as f:
             hashes.append(sha256_file(f))

--- a/platform/bazel/package.bzl
+++ b/platform/bazel/package.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
 load("//bazel:version.bzl", "hash_compute", "version_compute")
 load("//bazel:oci_digest.bzl", "oci_digest")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")

--- a/platform/bazel/version.bzl
+++ b/platform/bazel/version.bzl
@@ -1,4 +1,3 @@
-
 def _escape(s):
     return "'" + s.replace("$", "$$").replace("'", "'\"'\"'") + "'"
 


### PR DESCRIPTION
Changes to bazel to fix various incompatibilities from upgrading to version 0.28

Some API changes happened.  handled by patching `zip_file`
- https://github.com/bazelbuild/bazel/issues/5817, #403 
- https://github.com/bazelbuild/bazel/issues/5818
- https://github.com/bazelbuild/bazel/issues/5825

bugfix in bazel exposes a minor error in one of our BUILD files, fixed
- https://github.com/bazelbuild/bazel/issues/7513

rules_go no longer declares some modules we were using, so we import those ourselves
- https://github.com/bazelbuild/rules_go/blob/0.19.0/go/workspace.rst#proto-dependencies

However, the big problem is changes around python 2/3 version:
- https://github.com/bazelbuild/bazel/issues/7899
- https://github.com/bazelbuild/bazel/issues/7359

problem with pkg_deb, can be partially solved by migrating to rules_pkg 0.2.0's `pkg_deb` (see https://github.com/bazelbuild/bazel/issues/8489):
- https://github.com/bazelbuild/rules_pkg/issues/35

however, there's a python3 bug in containerregistry (which seems kinda poorly maintained) which isn't yet fixed.  (and doesn't have any sign of being fixed soon)
- https://github.com/google/containerregistry/issues/153

And the new fix for rules_pkg fails to be python2 compatible:
- https://github.com/bazelbuild/rules_pkg/issues/61

So I downgraded rules_pkg back to 0.1.0 and forced python 2 for now.  (Which is also what rules_k8s did, see https://github.com/bazelbuild/rules_k8s/issues/305)

However, we hit another containerregistry bug which I don't understand.  Didn't check if it occurs with previous version of bazel yet.

```
$ bazel build @containerregistry//:pusher.par --host_force_python=PY2 --sandbox_debug --verbose_failures         
INFO: Analyzed target @containerregistry//:pusher.par (30 packages loaded, 486 targets configured).
INFO: Found 1 target...
ERROR: [...]/external/containerregistry/BUILD.bazel:67:1: Building par file @containerregistry//:pusher.par failed (Exit 1) process-wrapper failed: error executing command 
  (cd [...]/sandbox/processwrapper-sandbox/12104/execroot/__main__ && \
  exec env - \
    PATH=/usr/local/bin:/usr/bin:/bin \
    TMPDIR=/tmp \
  [...]/_embedded_binaries/process-wrapper '--timeout=0' '--kill_delay=15' bazel-out/host/bin/external/subpar/compiler/compiler.par --manifest_file bazel-out/k8-fastbuild/bin/external/containerregistry/pusher.par_SOURCES --outputpar bazel-out/k8-fastbuild/bin/external/containerregistry/pusher.par --stub_file bazel-out/k8-fastbuild/bin/external/containerregistry/pusher --zip_safe True external/containerregistry/tools/fast_pusher_.py)
src/main/tools/process-wrapper-legacy.cc:58: "execvp(bazel-out/host/bin/external/subpar/compiler/compiler.par, ...)": No such file or directory
Target @containerregistry//:pusher.par failed to build
INFO: Elapsed time: 0.417s, Critical Path: 0.08s
INFO: 2 processes: 2 processwrapper-sandbox.
FAILED: Build did NOT complete successfully
```

There's probably other python 2/3 bugs that I didn't hit because I couldn't get past the containerregistry one.

---

Checklist:

 - [ ] I have split up this change into one or more appropriately-delineated commits.
 - [ ] The first line of each commit is of the form "[component]: do something"
 - [ ] I have written a complete, multi-line commit message for each commit.
 - [ ] I have formatted any Go code that I have changed with gofmt.
 - [ ] I have signed each commit with my GPG key.
 - [ ] My changes have passed CI.
 - [ ] I have built my changes locally, and tested that the changes work as expected.
 - [ ] I have deployed a cluster incorporating my changes, and checked that it deploys successfully.
 - [ ] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [ ] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
