### PR TITLE
debian: bump debian installer version to deb9u7+b2

### DIFF
--- a/debian-checksum.sh
+++ b/debian-checksum.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -u
 
-VERSION="20170615+deb9u6"
+VERSION="20170615+deb9u7+b2"
 
 WORK=$(mktemp -d)
 trap "rm -r $WORK" EXIT

--- a/platform/WORKSPACE
+++ b/platform/WORKSPACE
@@ -97,8 +97,8 @@ go_repository(
 
 http_file(
     name = "debian_iso",
-    urls = ["http://ftp.debian.org/debian/dists/stretch/main/installer-amd64/20170615+deb9u6/images/netboot/mini.iso"],
-    sha256 = "53583c1bd3808aab8629faf16d57aad32ae791e77ec52b7c283f0f4efda69b24"
+    urls = ["http://ftp.debian.org/debian/dists/stretch/main/installer-amd64/20170615+deb9u7+b2/images/netboot/mini.iso"],
+    sha256 = "6a1f4457430285dcd6882829eb5b96e840e06b0e792c2bdf2d91ce552da19d84",
 )
 
 # dnsmasq


### PR DESCRIPTION
A new build of debian is out, and it broke the build, because the old ISO is no longer being hosted by upstream. Bump the version so that our builds work again.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [ ] My changes have passed CI, including an automatic Jenkins deploy.
 - [ ] My changes have passed code review.
