### PR TITLE
spire: increase timeout for launching ocis

### DIFF
--- a/platform/spire/src/seq.py
+++ b/platform/spire/src/seq.py
@@ -78,7 +78,7 @@ def sequence_cluster(ops: setup.Operations) -> None:
     ops.add_operation("verify that kubernetes has launched successfully",
                       iterative_verifier(verify.check_kube_health, 120.0))
 
-    ops.add_operation("verify that containers can be pulled from the registry", iterative_verifier(verify.check_pull, 60.0))
+    ops.add_operation("verify that containers can be pulled from the registry", iterative_verifier(verify.check_pull, 120.0))
     ops.add_operation("verify that flannel is online", iterative_verifier(verify.check_flannel, 210.0))
     ops.add_operation("verify that dns-addon is online", iterative_verifier(verify.check_dns, 120.0))
 


### PR DESCRIPTION
The OCI launch step on jenkins fails intermittently. This is likely because the OCI launch step can timeout with the current setting. This change doubles that timeout to make it highly unlikely that we will see this failure mode in the future. See #409.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [x] My changes have passed CI, including an automatic Jenkins deploy.
 - [x] My changes have passed code review.
