### PR TITLE
Fix USB drive installer handling

### DIFF
--- a/platform/spire/resources/prepartition.sh
+++ b/platform/spire/resources/prepartition.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e -u
+echo "launching prepartition"
+
+# get the /dev/sdX device for the installer, stripping off the partition number.
+ISOIMAGE="$(readlink -f /dev/disk/by-label/ISOIMAGE | tr -d 1234567890)"
+
+CHOSEN_DISK=""
+
+# assuming that there are two disks, the installer and the hard disk, select the hard disk
+for disk in $(list-devices disk)
+do
+    if [ "${disk}" != "${ISOIMAGE}" ]
+    then
+        if [ "${CHOSEN_DISK}" = "" ]
+        then
+            CHOSEN_DISK="${disk}"
+        else
+            echo "too many valid disks: at least ${CHOSEN_DISK} ${disk}"
+            exit 1
+        fi
+    fi
+done
+
+if [ "${CHOSEN_DISK}" = "" ]
+then
+    echo "no available disks"
+    exit 1
+fi
+
+echo "selected device: ${CHOSEN_DISK}"
+debconf-set partman-auto/disk "${CHOSEN_DISK}"
+debconf-set grub-installer/bootdev "${CHOSEN_DISK}"

--- a/platform/spire/resources/preseed.cfg.in
+++ b/platform/spire/resources/preseed.cfg.in
@@ -428,8 +428,7 @@ d-i apt-setup/cdrom/set-next boolean false
 # This command is run immediately before the partitioner starts. It may be
 # useful to apply dynamic partitioner preseeding that depends on the state
 # of the disks (which may not be visible when preseed/early_command runs).
-#d-i partman/early_command \
-#       string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
+d-i partman/early_command string /prepartition.sh
 # This command is run just before the install finishes, but when there is
 # still a usable /target directory. You can chroot to /target and use it
 # directly, or use the apt-install and in-target commands to easily install

--- a/platform/spire/src/iso.py
+++ b/platform/spire/src/iso.py
@@ -61,9 +61,12 @@ def gen_iso(iso_image, authorized_key, mode=None):
         inclusion += ["dns_bootstrap_lines"]
         util.copy(authorized_key, os.path.join(d, "authorized.pub"))
         util.writefile(os.path.join(d, "keyservertls.pem"), authority.get_pubkey_by_filename("./clusterca.pem"))
-        resource.copy_to("postinstall.sh", os.path.join(d, "postinstall.sh"))
-        os.chmod(os.path.join(d, "postinstall.sh"), 0o755)
-        inclusion += ["authorized.pub", "keyservertls.pem", "postinstall.sh"]
+        inclusion += ["authorized.pub", "keyservertls.pem"]
+
+        for script in ["postinstall.sh", "prepartition.sh"]:
+            resource.copy_to(script, os.path.join(d, script))
+            os.chmod(os.path.join(d, script), 0o755)
+            inclusion.append(script)
 
         util.writefile(os.path.join(d, "keyserver.domain"), configuration.get_keyserver_domain().encode())
         inclusion.append("keyserver.domain")


### PR DESCRIPTION
I encountered trouble when I last tried to install on real hardware due to using a USB install drive instead of a CDROM. (We had been simulating a CDROM installer in our VM tests.)

This commit fixes this by:
 - Changing the autoinstaller to emulate the case where the installer is a USB hard drive, which reveals the problem in our integration tests.
 - Adding code to automatically select which hard drive to use for installation, ignoring USB drives.
 - Adding code to work around an issue in the debian installer that prevents grub from using the UUID of the main hard drive when booting.

See #337, which may be fixed by this. Fixes #338.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] ~I have written or updated appropriate documentation to cover this change.~ No documentation is required.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [x] My changes have passed CI, including an automatic Jenkins deploy.
 - [x] My changes have passed code review.
