### PR TITLE
163 add config redeploy

### DIFF
--- a/platform/keysystem/keyserver/keyserver.go
+++ b/platform/keysystem/keyserver/keyserver.go
@@ -16,13 +16,11 @@ func main() {
 	_, onstop, err := keyapi.Run(":20557", logger)
 	if err != nil {
 		logger.Fatal(err)
-	} else {
-		err := exec.Command("systemd-notify", "--ready").Run()
-		if err != nil {
-			logger.Fatal("failed to notify systemd of readiness: %v\n", err)
-		} else {
-			// service is up, wait for kill signal
-			logger.Fatal(<-onstop)
-		}
 	}
+	err = exec.Command("systemd-notify", "--ready").Run()
+	if err != nil {
+		logger.Fatal("failed to notify systemd of readiness: %v\n", err)
+	}
+	// service is up, wait for kill signal
+	logger.Fatal(<-onstop)
 }

--- a/platform/keysystem/keyserver/keyserver.go
+++ b/platform/keysystem/keyserver/keyserver.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"os/exec"
 
 	"github.com/sipb/homeworld/platform/keysystem/keyserver/keyapi"
 )
@@ -16,6 +17,12 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	} else {
-		logger.Fatal(<-onstop)
+		err := exec.Command("systemd-notify", "--ready").Run()
+		if err != nil {
+			logger.Fatal("failed to notify systemd of readiness: %v\n", err)
+		} else {
+			// service is up, wait for kill signal
+			logger.Fatal(<-onstop)
+		}
 	}
 }

--- a/platform/keysystem/systemd/keyserver.service
+++ b/platform/keysystem/systemd/keyserver.service
@@ -4,6 +4,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+Type=notify
 ExecStart=/usr/bin/keyserver
 Restart=always
 RestartSec=10s

--- a/platform/spire/src/seq.py
+++ b/platform/spire/src/seq.py
@@ -60,6 +60,14 @@ def sequence_supervisor(ops: command.Operations, skip_verify_keygateway: bool=Fa
         if node.kind == 'supervisor':
             ops.add_subcommand(infra.infra_sync, node.hostname)
 
+@command.wrapseq
+def sequence_redeploy_config(ops: setup.Operations) -> None:
+    "redeploy a cluster configuration to a running cluster"
+    # push new config to the keyserver
+    ops.add_subcommand(setup.redeploy_keyserver)
+    # push new config to each keyclient and restart
+    ops.add_subcommand(setup.redeploy_keyclients)
+
 
 class IterativeVerifier(command.Simple):
     def __init__(self, verifier, max_time, pause=2.0):
@@ -122,4 +130,5 @@ main_command = command.SeqMux("commands about running large sequences of cluster
     "ssh": sequence_ssh,
     "supervisor": sequence_supervisor,
     "cluster": sequence_cluster,
+    "redeploy": sequence_redeploy_config,
 })

--- a/platform/spire/src/seq.py
+++ b/platform/spire/src/seq.py
@@ -61,12 +61,12 @@ def sequence_supervisor(ops: command.Operations, skip_verify_keygateway: bool=Fa
             ops.add_subcommand(infra.infra_sync, node.hostname)
 
 @command.wrapseq
-def sequence_redeploy_config(ops: setup.Operations) -> None:
+def sequence_redeploy_config(ops: command.Operations) -> None:
     "redeploy a cluster configuration to a running cluster"
     # push new config to the keyserver
-    ops.add_subcommand(setup.redeploy_keyserver)
+    setup.redeploy_keyserver(ops)
     # push new config to each keyclient and restart
-    ops.add_subcommand(setup.redeploy_keyclients)
+    setup.redeploy_keyclients(ops)
 
 
 class IterativeVerifier(command.Simple):

--- a/platform/spire/src/setup.py
+++ b/platform/spire/src/setup.py
@@ -85,8 +85,6 @@ def redeploy_keyserver(ops: Operations) -> None:
                             configuration.Config.get_setup_path(), CONFIG_DIR + "/setup.yaml")
         # restart the keyserver
         ops.ssh("restart keyserver on @HOST", node, "systemctl", "restart", "keyserver.service")
-        # TODO: eliminate sleep by only finishing previous command only when service is restarted.
-        ops.ssh("waiting for keyserver to come back up on @HOST", node, "sleep", "5")
 
 def redeploy_keyclients(ops: Operations) -> None:
     config = configuration.get_config()

--- a/platform/spire/src/setup.py
+++ b/platform/spire/src/setup.py
@@ -70,31 +70,32 @@ def setup_keyserver(ops: command.Operations) -> None:
         ssh_cmd(ops, "enable keyserver on @HOST", node, "systemctl", "enable", "keyserver.service")
         ssh_cmd(ops, "start keyserver on @HOST", node, "systemctl", "restart", "keyserver.service")
 
-def redeploy_keyserver(ops: Operations) -> None:
+def redeploy_keyserver(ops: command.Operations) -> None:
     config = configuration.get_config()
     for node in config.nodes:
         if node.kind != "supervisor":
             continue
         # delete the existing configs
-        ops.ssh_rm("delete existing cluster config from @HOST", node, STATICS_DIR + "/cluster.conf")
-        ops.ssh_rm("delete existing keyserver config from @HOST", node, CONFIG_DIR + "/setup.yaml")
+        ssh_cmd(ops, "delete existing cluster config from @HOST", node, "rm", "-f", STATICS_DIR + "/cluster.conf")
+        ssh_cmd(ops, "delete existing keyserver config from @HOST", node,"rm", "-f", CONFIG_DIR + "/setup.yaml")
         # redeploy new config
-        ops.ssh_upload_bytes("reupload cluster config to @HOST", node,
+        ssh_upload_bytes(ops, "reupload cluster config to @HOST", node,
             configuration.get_cluster_conf().encode(), STATICS_DIR + "/cluster.conf")
-        ops.ssh_upload_path("upload cluster setup to @HOST", node,
+        ssh_upload_path(ops, "upload cluster setup to @HOST", node,
                             configuration.Config.get_setup_path(), CONFIG_DIR + "/setup.yaml")
         # restart the keyserver
-        ops.ssh("restart keyserver on @HOST", node, "systemctl", "restart", "keyserver.service")
+        ssh_cmd(ops, "restart keyserver on @HOST", node, "systemctl", "restart", "keyserver.service")
 
-def redeploy_keyclients(ops: Operations) -> None:
+def redeploy_keyclients(ops: command.Operations) -> None:
     config = configuration.get_config()
     for node in config.nodes:
-        # delete existing cluster configuration from non-supervisor nodes
+        # do not delete the cluster.conf on the supervisor because the
+        # keyclient and keyserver on the supervisor use the same cluster.conf
         if node.kind != "supervisor":
-            ops.ssh_rm("delete existing cluster config from @HOST", node, CONFIG_DIR + "/cluster.conf")
-        ops.ssh_rm("delete existing local config from @HOST", node, CONFIG_DIR + "/local.conf")
+            ssh_cmd(ops, "delete existing cluster config from @HOST", node, "rm", "-f", CONFIG_DIR + "/cluster.conf")
+        ssh_cmd(ops, "delete existing local config from @HOST", node, "rm", "-f", CONFIG_DIR + "/local.conf")
         # restart local keyclient (will regenerate configs on restart)
-        ops.ssh("restart keyclient daemon on @HOST", node, "systemctl", "restart", "keyclient.service")
+        ssh_cmd(ops, "restart keyclient daemon on @HOST", node, "systemctl", "restart", "keyclient.service")
 
 @command.wrapop
 def admit_keyserver(ops: command.Operations) -> None:


### PR DESCRIPTION
Spire does not have a convenient way to redeploy a cluster configuration to a running cluster. This change adds a command `spire seq redeploy` which takes the current cluster configuration from `setup.yaml` and redeploys it to a running cluster. This change simply pushes the new config to each of the cluster nodes, and restarts their respective keyclient (or in the case of the supervisor, keyserver) services.

This change also allows the keyserver to notify systemd when it is up, using the same mechanism as is used by the keyclient. In working on this change, I have noticed that restarting the keyclient may take more than five minutes, simply because the keyclient fails to receive the new config from the keyserver as a result of the keyserver not being up before we restart the keyclients. As a result the keyclient would fail and wait 5 minutes to restart. Allowing the keyserver to notify systemd when it is up again means that spire can sequence the operations needed to redeploy the config without waiting an arbitrary amount of time, or pinging the keyserver to see if the keyserver is responding to http.

See #163.


---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [ ] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [x] My changes have passed CI, including an automatic Jenkins deploy.
 - [x] My changes have passed code review.
