### PR TITLE
deploy-chroot: fix systemd-nspawn on buster

### DIFF
--- a/deploy-chroot/enter.sh
+++ b/deploy-chroot/enter.sh
@@ -17,6 +17,7 @@ sudo systemd-nspawn \
      -E PATH="/usr/local/bin:/usr/bin:/bin:/homeworld/deploy-chroot" \
      -E HOMEWORLD_DIR="/cluster" \
      -E HOMEWORLD_DISASTER="/disaster" \
+     --keep-unit \
      --register=no \
      -M "$(basename "$HOMEWORLD_DEPLOY_CHROOT")" \
      --bind "$(pwd)":/homeworld:norbind \


### PR DESCRIPTION
Something changed about how permissions work under Debian Buster, so now that our development machine is on Buster, we have to pass systemd-nspawn the `--keep-unit` parameter to make it able to run the mknod command from within the chroot.

It also appears that, without `--keep-unit`, we end up potentially using the same machine scope (such as deploy-chroot.scope) when we have similarly-named deploy chroot directories. Adding `--keep-unit` fixes this as well.

No filed issue is associated.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [x] My changes have passed CI, including an automatic Jenkins deploy.
 - [ ] My changes have passed code review.
