### PR TITLE
spire: support -- separator properly

### DIFF
--- a/platform/spire/src/access.py
+++ b/platform/spire/src/access.py
@@ -234,6 +234,8 @@ def call_etcdctl(params: list, return_result: bool):
 @command.wrap
 def dispatch_etcdctl(*params: str):
     "invoke commands through the etcdctl wrapper"
+    if params and params[0] == '--':
+        params = params[1:]
     call_etcdctl(params, False)
 
 
@@ -257,12 +259,16 @@ def call_kubectl(params, return_result: bool):
 @command.wrap
 def dispatch_kubectl(*params: str):
     "invoke commands through the kubectl wrapper"
+    if params and params[0] == '--':
+        params = params[1:]
     call_kubectl(params, False)
 
 
 @command.wrapop
 def ssh_foreach(ops: command.Operations, node_kind: str, *params: str):
     "invoke commands on every node (or every node of a given kind) in the cluster"
+    if params and params[0] == '--':
+        params = params[1:]
     config = configuration.get_config()
     valid_node_kinds = configuration.Node.VALID_NODE_KINDS
     if not (node_kind == "node" or node_kind == "kube" or node_kind in valid_node_kinds):


### PR DESCRIPTION
This works around a bug in argparse which fails to strip `--` from
arguments of type `REMAINDER`.

Closes #505.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [x] My changes have passed CI, including an automatic Jenkins deploy.
 - [x] My changes have passed code review.
