### PR TITLE
spire: don't scan for supervisor keys during auto-launch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 jobs:
+  check-linear:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Check git history of branch is linear
+          command: tools/check-linear.sh
   build:
     machine:
       image: ubuntu-1604:201903-01
@@ -34,8 +42,15 @@ jobs:
           command: echo "bazel build //upload --verbose_failures" | HOMEWORLD_CHROOT="$HOME/autobuild-chroot" USER="circleci" ./build-chroot/enter-ci.sh
 workflows:
   version: 2
-  build:
+  workflow:
     jobs:
+      - check-linear:
+          filters:
+            branches:
+              ignore:
+                - staging
+                - trying
+                - master
       - build:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     machine:
@@ -32,3 +32,14 @@ jobs:
       - run:
           name: Launch build with bazel
           command: echo "bazel build //upload --verbose_failures" | HOMEWORLD_CHROOT="$HOME/autobuild-chroot" USER="circleci" ./build-chroot/enter-ci.sh
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - staging
+                - trying
+                - master

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,9 @@ status = [
   "ci/circleci: build",
   "continuous-integration/jenkins/branch",
 ]
+pr_status = [
+  "ci/circleci: check-linear",
+]
 required_approvals = 1
 timeout_sec = 10800 # three hour timeout
 cut_body_after = "---"

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,11 @@
+status = [
+  "ci/circleci: build",
+  "continuous-integration/jenkins/branch",
+]
+required_approvals = 1
+timeout_sec = 10800 # three hour timeout
+cut_body_after = "---"
+
+[committer]
+name = "hyades-bors[bot]"
+email = "sipb-hyades@mit.edu"

--- a/docs/bors-ng-setup.txt
+++ b/docs/bors-ng-setup.txt
@@ -1,25 +1,38 @@
-exit # not quite a script; some parts are interactive.
+exit  # this isn't quite a script; some parts are interactive.
 
-# Requires nginx setup from jenkins-setup.txt
+### Register Github App
 # https://github.com/bors-ng/bors-ng#step-1-register-a-new-github-app
 # Dashboard URL: https://hijinks.mit.edu:4002/
+# Generate and download a private key (.pem file)
+
+
+### Install dependencies
 
 wget -q -O - https://packages.erlang-solutions.com/debian/erlang_solutions.asc | apt-key add -
 echo 'deb https://packages.erlang-solutions.com/debian stretch contrib' >/etc/apt/sources.list.d/erlang-solutions.list
+
+wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+echo 'deb https://deb.nodesource.com/node_13.x stretch main' >/etc/apt/sources.list.d/nodesource.list
+
 apt-get update
-apt-get install esl-erlang elixir postgresql
+apt-get install esl-erlang elixir postgresql nodejs
 
 
-# use this command to generate random secrets when called for
-</dev/urandom tr -dc 'a-zA-Z0-9' | head -c64
+# use this command to generate random secrets when called for:
+# </dev/urandom tr -dc 'a-zA-Z0-9' | head -c64
 
+### User
 useradd -m -U borsng
 
-sudo -u postgres createuser -P borsng # generate random password
+
+### Database
+sudo -u postgres createuser -P borsng  # generate a random db password
 sudo -u postgres createdb -O borsng borsng
 sudo -u postgres psql -d borsng <<<"CREATE EXTENSION IF NOT EXISTS citext;"
 
-# add this location block to /etc/nginx/sites-available/hijinks
+
+### Nginx configuration: requires existing nginx+certbot setup from jenkins-setup.txt
+# Add this location block to /etc/nginx/sites-available/hijinks
 cat <<EOF
 server {
   listen 4002 ssl;
@@ -44,6 +57,7 @@ server {
 }
 EOF
 
+### Systemd configuration
 cat <<EOF >borsng.service
 [Unit]
 Description=Bors-NG
@@ -74,21 +88,28 @@ cd bors-ng
 mix local.hex --force
 mix deps.get --only prod
 mix local.rebar --force
+
+pushd assets
+npm install
+popd
+npm run deploy --prefix ./assets
+MIX_ENV=prod mix phx.digest
+
 MIX_ENV=prod mix compile
 MIX_ENV=prod mix release
+
 
 cat >~/bors-env <<EOF
 PORT=4001
 MIX_ENV=prod
-SECRET_KEY_BASE=<generate random>
-DATABASE_URL='ecto://borsng:<db password>@localhost/borsng'
-GITHUB_INTEGRATION_ID=<app id>
-GITHUB_INTEGRATION_PEM='<output from "">'
-GITHUB_WEBHOOK_SECRET=<generate random, input to github>
-GITHUB_CLIENT_ID=<from github>
-GITHUB_CLIENT_SECRET=<from github>
+SECRET_KEY_BASE=???  # generate this randomly
+DATABASE_URL='ecto://borsng:<db password>@localhost/borsng'  # password from earlier
+GITHUB_INTEGRATION_ID=???  # App id in github
+GITHUB_WEBHOOK_SECRET=???  # generate this randomly and input it to github
+GITHUB_CLIENT_ID=???  # from github
+GITHUB_CLIENT_SECRET=???  # from github
 PUBLIC_HOST=localhost
 EOF
-echo "GITHUB_INTEGRATION_PEM='$(base64 -w0 /path/to/file.private-key.pem)'" >>~bors-env
+echo "GITHUB_INTEGRATION_PEM='$(base64 -w0 /path/to/file.private-key.pem)'" >>~bors-env  # private key from github
 
 sh -ac '. ~/bors-env && POOL_SIZE=1 mix ecto.migrate'

--- a/docs/bors-ng-setup.txt
+++ b/docs/bors-ng-setup.txt
@@ -1,0 +1,94 @@
+exit # not quite a script; some parts are interactive.
+
+# Requires nginx setup from jenkins-setup.txt
+# https://github.com/bors-ng/bors-ng#step-1-register-a-new-github-app
+# Dashboard URL: https://hijinks.mit.edu:4002/
+
+wget -q -O - https://packages.erlang-solutions.com/debian/erlang_solutions.asc | apt-key add -
+echo 'deb https://packages.erlang-solutions.com/debian stretch contrib' >/etc/apt/sources.list.d/erlang-solutions.list
+apt-get update
+apt-get install esl-erlang elixir postgresql
+
+
+# use this command to generate random secrets when called for
+</dev/urandom tr -dc 'a-zA-Z0-9' | head -c64
+
+useradd -m -U borsng
+
+sudo -u postgres createuser -P borsng # generate random password
+sudo -u postgres createdb -O borsng borsng
+sudo -u postgres psql -d borsng <<<"CREATE EXTENSION IF NOT EXISTS citext;"
+
+# add this location block to /etc/nginx/sites-available/hijinks
+cat <<EOF
+server {
+  listen 4002 ssl;
+  server_name hijinks.mit.edu;
+
+  # copied from jenkins' server block:
+  ssl_certificate /etc/letsencrypt/live/hijinks.mit.edu/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/hijinks.mit.edu/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+  ssl_trusted_certificate /etc/letsencrypt/live/hijinks.mit.edu/chain.pem;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security "max-age=31536000" always;
+
+  location / {
+    include /etc/nginx/proxy_params;
+    proxy_pass http://localhost:4001/;
+    proxy_redirect default;
+  }
+}
+EOF
+
+cat <<EOF >borsng.service
+[Unit]
+Description=Bors-NG
+After=network.target
+
+[Service]
+Type=simple
+User=borsng
+WorkingDirectory=/home/borsng/bors-ng
+EnvironmentFile=/home/borsng/bors-env
+Restart=on-failure
+ExecStart=/home/borsng/bors-ng/_build/prod/rel/bors/bin/bors start
+ExecStop=/home/borsng/bors-ng/_build/prod/rel/bors/bin/bors stop
+
+[Install]
+WantedBy=multi-user.target
+EOF
+ln -s "$(realpath borsng.service)" /etc/systemd/system
+systemctl enable borsng
+
+
+sudo -iu borsng  # run all remaining commands as borsng
+umask go=
+
+git clone https://github.com/bors-ng/bors-ng.git
+
+cd bors-ng
+mix local.hex --force
+mix deps.get --only prod
+mix local.rebar --force
+MIX_ENV=prod mix compile
+MIX_ENV=prod mix release
+
+cat >~/bors-env <<EOF
+PORT=4001
+MIX_ENV=prod
+SECRET_KEY_BASE=<generate random>
+DATABASE_URL='ecto://borsng:<db password>@localhost/borsng'
+GITHUB_INTEGRATION_ID=<app id>
+GITHUB_INTEGRATION_PEM='<output from "">'
+GITHUB_WEBHOOK_SECRET=<generate random, input to github>
+GITHUB_CLIENT_ID=<from github>
+GITHUB_CLIENT_SECRET=<from github>
+PUBLIC_HOST=localhost
+EOF
+echo "GITHUB_INTEGRATION_PEM='$(base64 -w0 /path/to/file.private-key.pem)'" >>~bors-env
+
+sh -ac '. ~/bors-env && POOL_SIZE=1 mix ecto.migrate'

--- a/platform/spire/src/virt.py
+++ b/platform/spire/src/virt.py
@@ -549,10 +549,10 @@ def auto_install_supervisor(ops: command.Operations, tc: TerminationContext, sup
 
 
 @command.wrapseq
-def auto_launch_supervisor(ops: command.Operations, tc: TerminationContext, supervisor: configuration.Node, debug_qemu=False):
+def auto_launch_supervisor(ops: command.Operations, tc: TerminationContext, supervisor: configuration.Node, autoadd_fingerprint=False, debug_qemu=False):
     # TODO: annotations, so that this can be --dry-run'd
     vm = VirtualMachine(supervisor, tc, debug_qemu=debug_qemu)
-    ops.add_operation("start up supervisor node", lambda: vm.boot_launch(autoadd_fingerprint=True))
+    ops.add_operation("start up supervisor node", lambda: vm.boot_launch(autoadd_fingerprint=autoadd_fingerprint))
 
 
 @command.wrapseq
@@ -591,7 +591,7 @@ def auto_install(ops: command.Operations, authorized_key=None, persistent: bool=
         with ops.context("termination", TerminationContext()) as tc:
             with ops.context("debug shell", DebugContext(persistent)):
                 ops.add_subcommand(auto_install_supervisor, tc, config.keyserver, iso_path, cdrom_install=cdrom_install, debug_qemu=debug_qemu)
-                ops.add_subcommand(auto_launch_supervisor, tc, config.keyserver, debug_qemu=debug_qemu)
+                ops.add_subcommand(auto_launch_supervisor, tc, config.keyserver, autoadd_fingerprint=True, debug_qemu=debug_qemu)
                 ops.add_subcommand(seq.sequence_supervisor)
 
                 other_nodes = [n for n in config.nodes if n != config.keyserver]

--- a/tools/check-linear.sh
+++ b/tools/check-linear.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ 0 = "$(git rev-list --min-parents=2 --count "$(git merge-base origin/master HEAD)"..HEAD)" ]
+then
+    echo 'git history is linear'
+else
+    echo 'error: nonlinear branch git history'
+    echo 'merge commits:'
+    git rev-list --min-parents=2 "$(git merge-base origin/master HEAD)"..HEAD
+    exit 1
+fi


### PR DESCRIPTION
When launching an existing virtual cluster, don't attempt to
authenticate to the supervisor with the pre-keysystem method
of using the preseeded authorized ssh key.
Doing so won't work because that ssh key is no longer authorized
on the supervisor after the keysystem is set up.
(Previously, it sometimes appeared to work when the
keysystem-provided ssh keys were still loaded from a prior
auto-install.)

This also avoids unnecessarily pulling the host key
from the keysystem and verifying it using the fingerprint
displayed on the supervisor console; once the keysystem is
set up the supervisor can authenticate itself using the CA.

---

Checklist:

 - [x] I have split up this change into one or more appropriately-delineated commits.
 - [x] The first line of each commit is of the form "[component]: do something"
 - [x] I have written a complete, multi-line commit message for each commit.
 - [x] I have formatted any Go code that I have changed with gofmt.
 - [x] I have written or updated appropriate documentation to cover this change.
 - [x] I have confirmed that this change is covered by at least one appropriate test run by CI.
 - [x] If my change includes new or modified functionality, I have tested that the changes work as expected.
 - [x] I have assigned this issue to an appropriate reviewer. (Choose @celskeggs if you are not otherwise certain.)
 - [x] I consider my PR complete and ready to be merged without my further input, assuming that it passes CI and code review.
 - [ ] My changes have passed CI, including an automatic Jenkins deploy.
 - [x] My changes have passed code review.
